### PR TITLE
Update Mrk Industries name and EITI cleanup

### DIFF
--- a/content/discover/made-with-kicad.html
+++ b/content/discover/made-with-kicad.html
@@ -199,9 +199,9 @@ title = "Made with KiCad"
             </div>
             <div class="col-md-7">
                 <h3>Electrosmart ECG</h3>
-                <h4>Mrk Industries</h4>
-                <p>10 lead ECG with an ARM Cortex M3, USB and Bluetooth, developed and sold in partnership with Eccosur.</p>
-                <a class="btn btn-primary" href="http://www.mrkindustries.com.ar/desarrollos/electrosmart-ecg/">View Project <span class="glyphicon glyphicon-chevron-right"></span></a>
+                <h4>Palta Tech</h4>
+                <p>12 lead ECG with an ARM Cortex M3, USB and Bluetooth, developed and sold in partnership with Eccosur.</p>
+                <a class="btn btn-primary" href="http://www.paltatech.com/electrosmart/">View Project <span class="glyphicon glyphicon-chevron-right"></span></a>
             </div>
         </div>
         <!-- /.row -->
@@ -215,12 +215,12 @@ title = "Made with KiCad"
             </div>
             <div class="col-md-7">
                 <h3>Electronic Industrial Temperature Interface</h3>
-                <h4>Mrk Industries</h4>
-                <p>EITI is a powerful addition to a PLC/MODBUS based design.
-                The Electronic Industrial Temperature Interface (EITI) will measure temperature sensor
-                signals, communicate via a RX or TX current loop signal and communicate with other
-                devices over MODBUS. This allows a PLC to interface with many common analog signals.</p>
-                <a class="btn btn-primary" href="http://www.mrkindustries.com.ar/desarrollos/eiti/">View Project <span class="glyphicon glyphicon-chevron-right"></span></a>
+                <h4>Palta Tech</h4>
+                <p>EITI is an I/O module for a PLC/MODBUS based design.
+                The board measures temperature signals, communicate via a RX or TX 4-20mA current loop signal
+                and communicate with other devices over MODBUS. This allows a PLC to interface with
+                many common analog signals.</p>
+                <a class="btn btn-primary" href="http://www.paltatech.com/eiti/">View Project <span class="glyphicon glyphicon-chevron-right"></span></a>
             </div>
         </div>
         <!-- /.row -->


### PR DESCRIPTION
Mrk Industries was relaunched as Palta Tech (www.paltatech.com) this year. Also, EITI description was a bit too long so I made it more concise.