### PR TITLE
Add a sidebar to download subpages

### DIFF
--- a/layouts/download/single.html
+++ b/layouts/download/single.html
@@ -1,0 +1,52 @@
+{{ partial "header.html" . }}
+
+<style type='text/css'>
+	.download-os div {
+	    display: inline;
+	}
+</style>
+
+<div class="container">
+	<div class="col-sm-10 margin-20">
+		<!-- Main Content -->
+        {{ partial "breadcrumb.html" . }}
+
+        <div class="page-heading">
+            <h1>{{ title .Title }}</h1>
+            <hr class="small">
+            <span class="subheading">{{ title .Description }}</span>
+        </div>
+        <div class="row">
+            <div class="col-lg-12 col-md-10 ">
+              {{ .Content }}
+            </div>
+        </div>
+	</div>
+	
+	<!--sidebar start-->
+	{{ $currentNode := . }}
+	<div class="col-sm-2">
+	    <aside>
+		<nav class="secondary">
+		    <!-- sidebar menu start-->
+		    <h3>All&nbsp;Platforms</h3>
+		    <ul class="list-unstyled side-links">
+			{{ range .Site.Sections.download.Pages }}
+			     <li class="list-group-item download-os">
+				    <a href="{{ .Permalink }}">
+					    {{ .Params.iconhtml | safeHTML }}
+					    {{ .Title }}
+				    </a>
+			     </li>
+			{{end}}
+		     </ul>
+		    </ul>
+		    <!-- sidebar menu end-->
+		</nav>
+	    </aside>
+	</div>
+	<!--sidebar end-->
+	
+</div>
+
+{{ partial "footer.html" . }}

--- a/layouts/download/single.html
+++ b/layouts/download/single.html
@@ -30,9 +30,9 @@
 		<nav class="secondary">
 		    <!-- sidebar menu start-->
 		    <h3>All&nbsp;Platforms</h3>
-		    <ul class="list-unstyled side-links">
+		    <ul class="list-unstyled side-links list-group">
 			{{ range .Site.Sections.download.Pages }}
-			     <li class="list-group-item download-os">
+			     <li class="list-group-item download-os{{if eq $currentNode . }} active{{end}}">
 				    <a href="{{ .Permalink }}">
 					    {{ .Params.iconhtml | safeHTML }}
 					    {{ .Title }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -7,7 +7,7 @@
             <!-- sidebar menu start-->
               {{ $section := .Scratch.Get "sidemenu_section" }}
               {{ range .Site.Menus.main }}
-                    {{ if eq $section (.Name | lower) }}
+                  {{ if eq $section (.Name | lower) }}
                         {{ if .HasChildren }}
                             <h3>{{ .Name }}</h3>
                             <ul class="list-unstyled side-links">

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -10,9 +10,9 @@
                   {{ if eq $section (.Name | lower) }}
                         {{ if .HasChildren }}
                             <h3>{{ .Name }}</h3>
-                            <ul class="list-unstyled side-links">
+                            <ul class="list-unstyled side-links list-group">
                                 {{ range .Children }}
-                                    <li{{if $currentNode.IsMenuCurrent "main" . }} class="active"{{end}}><a href="{{.URL}}"> {{ .Name }} </a> </li>
+                                    <li class="list-group-item{{if $currentNode.IsMenuCurrent "main" . }} active{{end}}"><a href="{{.URL}}"> {{ .Name }} </a> </li>
                                 {{ end }}
                             </ul>
                         {{end}}

--- a/static/css/kicad.css
+++ b/static/css/kicad.css
@@ -30,6 +30,9 @@ h6 {
 a { color: #404040 }
 a:hover,
 a:focus { color: #0085a1 }
+.side-links .active a {
+    color: white;
+}
 .thumbnail img:hover,
 .thumbnail img:focus { cursor: zoom-in }
 blockquote {


### PR DESCRIPTION
Add a sidebar to navigate between the sub pages of the download section.
I am not proud of having copied the layout file but could not figure out a better way.

Additionally, I enclosed all sidebars in pills to separate them from the page contents.