### PR TITLE
Fix typo in CSS: content-section justification

### DIFF
--- a/static/css/kicad.css
+++ b/static/css/kicad.css
@@ -191,7 +191,7 @@ hr.small {
     .intro-header .post-heading h1 { font-size: 55px }
     .intro-header .post-heading .subheading { font-size: 30px }
 }
-.content-section-a, content-section-b { /*index.html*/
+.content-section-a, .content-section-b { /*index.html*/
     text-align: justify;
 }
 .post-preview>a { color: #404040 }


### PR DESCRIPTION
A typo in the CSS has made the two columns on the front page have unequal text justification.