### PR TITLE
Rewrite Ubuntu download instructions

### DIFF
--- a/content/download/ubuntu.adoc
+++ b/content/download/ubuntu.adoc
@@ -4,16 +4,27 @@ iconhtml = "<div class='fl-ubuntu'></div>"
 weight = 1
 +++
 
-=== Unstable Builds
+=== Development Builds
 Daily builds are available in https://code.launchpad.net/~js-reynaud/+archive/ubuntu/ppa-kicad[js-reynaud's PPA].
-Execute this in a terminal to use it:
-[source,bash]
-sudo add-apt-repository ppa:js-reynaud/ppa-kicad && sudo apt-get update && sudo apt-get install kicad
+These provide the latest, unreleased preview of KiCad.
+To install KiCad via the PPA, you can use the Ubuntu Software Center:
 
-=== Stable Version
-This version is in preparation. Until its release, please use js-reynaud's PPA.
+1. Open the Ubuntu Software Center.
+2. Select Edit → Software Sources.
+3. Open the 'Other Software' tab.
+4. Click 'Add', and enter the PPA address: `ppa:js-reynaud/ppa-kicad`
+
+If you prefer to use the shell, you can enter these commands into a terminal:
+
+[source,bash]
+sudo add-apt-repository ppa:js-reynaud/ppa-kicad
+sudo apt-get update
+sudo apt-get install kicad
 
 === Old Stable
-Old stable should be in the official Ubuntu repository. Search for `KiCad` in the 'software center' or execute:
+The most recent full release of KiCad is old, and not recommended for new projects.
+If you want it, Old Stable is the official Ubuntu repository.
+Search for `KiCad` in the Ubuntu Software Center or execute the following in a terminal:
+
 [source,bash]
 sudo apt-get install kicad


### PR DESCRIPTION
Add more user-friendly download instructions for Ubuntu. Ubuntu users don't usually like to be slapped with shell commands.