### PR TITLE
mention yet more file formats used by the KiCad project

### DIFF
--- a/content/help/file-formats.adoc
+++ b/content/help/file-formats.adoc
@@ -94,7 +94,7 @@ link:http://www.freerouting.net/[FreeRouting]).
 
 === Other formats used by the KiCad project
 
-* `.pdf`: All the help documentation intended to be read by KiCad users is in "'.pdf'" format.
+* `.pdf`: All the help documentation intended to be read by KiCad users is in `.pdf` format.
 
 * EDIF (_Electronic Design Interchange Format_) netlist format.
 link:https://en.wikipedia.org/wiki/EDIF[Wikipedia]
@@ -103,3 +103,6 @@ link:https://en.wikipedia.org/wiki/EDIF[Wikipedia]
 good format for posting a section of a schematic (or a section of a PCB layout) to a web page, so people can see it immediately
 in a web browser without manually "downloading" or "installing" anything.
       
+* `.html` The text on the KiCad website is in HTML 5.
+
+* `.adoc`: All those `.pdf` files and `.html` files are automatically generated from source files in link:http://www.methods.co.nz/asciidoc/[AsciiDoc format]. We switched from `.odt` format to `.adoc` on 2015-02-09 because a link:http://en.wikipedia.org/wiki/Lightweight_markup_language[lightweight markup language] is easy to update with a wider variety of editing tools, and then much easier for our translators to see what changed and make corresponding improvements in other languages.


### PR DESCRIPTION
I'm surprised that this list of file formats doesn't yet mention ".adoc", the format that this list itself is in.
(Is there a good URL to a good explanation of *why* people decided to convert the KiCad documentation to ".adoc"?)