### PR TITLE
More homogenous content column, keep sidebar for medium grid

### DIFF
--- a/layouts/_default/archive.html
+++ b/layouts/_default/archive.html
@@ -1,7 +1,1 @@
-               <div class="post-preview">
-                  <p class="post-meta"><a href="{{ .Permalink }}">{{ .Title }}</a> on {{ dateFormat .Site.Params.DateForm .Date }}
-                    <br />
-                    {{ partial "categories.html" .}}
-                    {{ partial "tags.html" .}}
-                  </p>
-               </div>
+<!-- Unused -->

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,20 +1,28 @@
 {{ partial "header.html" . }}
 
-<!-- Main Content -->
+{{ .Scratch.Set "sidemenu" false }}
+
 <div class="container">
-	<div class="page-heading">
-		<h1>{{ title .Title }}</h1>
-	</div>
 	<div class="row">
-		<div class="col-md-8 col-md-offset-2">
-			<ul class="nav ">
-				{{ range .Paginator.Pages }}
-				<li>
-					<a href="{{ .RelPermalink }}">{{ .Title }}</a>
-				</li>
-				{{ end }}
-				{{ template "_internal/pagination.html" . }}
-			</ul>
+		<div class="col-lg-8 col-lg-offset-2 {{ if .Scratch.Get "sidemenu" }}col-md-10 col-sm-9{{ else }}col-sm-12{{ end }}">
+			{{ partial "breadcrumb.html" . }}
+
+			<div class="page-heading">
+				<h1>{{ title .Title }}</h1>
+			</div>
+
+			<div class="row">
+				<div class="col-md-8 col-md-offset-2">
+					<ul class="nav ">
+						{{ range .Paginator.Pages }}
+						<li>
+							<a href="{{ .RelPermalink }}">{{ .Title }}</a>
+						</li>
+						{{ end }}
+						{{ template "_internal/pagination.html" . }}
+					</ul>
+				</div>
+			</div>
 		</div>
 	</div>
 </div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,27 +1,29 @@
 {{ partial "header.html" . }}
 
-<div class="container">
-	{{ $currentNode := . }}
-	{{ .Scratch.Set "sidemenu" false }}
-	{{ .Scratch.Set "sidemenu_section" $currentNode.Section }}
-	{{ range .Site.Menus.main }}
-		{{ if eq $currentNode.Section (.Name | lower) }}
-			{{ if .HasChildren }}
-				{{ $currentNode.Scratch.Set "sidemenu" true }}
-			{{ end }}
+{{ $currentNode := . }}
+{{ .Scratch.Set "sidemenu" false }}
+{{ .Scratch.Set "sidemenu_section" $currentNode.Section }}
+{{ range .Site.Menus.main }}
+	{{ if eq $currentNode.Section (.Name | lower) }}
+		{{ if .HasChildren }}
+			{{ $currentNode.Scratch.Set "sidemenu" true }}
 		{{ end }}
 	{{ end }}
-    
-	<div class="col-lg-8 col-lg-offset-2">
-        {{ partial "breadcrumb.html" . }}
+{{ end }}
 
-	    <div class="page-heading">
-		<h1>{{ title .Title }}</h1>
-	    </div>
-	    {{ .Content }}
+<div class="container">
+	<div class="row">
+		<div class="col-lg-8 col-lg-offset-2 {{ if .Scratch.Get "sidemenu" }}col-md-10 col-sm-9{{ else }}col-sm-12{{ end }}">
+			{{ partial "breadcrumb.html" . }}
+
+			<div class="page-heading">
+				<h1>{{ replace .Title "-" " " }}</h1>
+			</div>
+			{{ .Content }}
+		</div>
+
+		{{ partial "sidebar.html" . }}
 	</div>
-	
-	{{ partial "sidebar.html" . }}
 </div>
 
 {{ partial "footer.html" . }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,17 +1,1 @@
-{{ partial "header.html" . }}
-
-    <!-- Main Content -->
-    <div class="container">
-      <div class="row">
-        <div class="col-lg-8 col-lg-offset-2">
-          <ul>
-            {{ $data := .Data }}
-            {{ range $key, $value := .Data.Terms.ByCount }}
-            <li><a href="/{{ $data.Plural }}/{{ $value.Name | urlize }}">{{ $value.Name | title }}</a> {{ $value.Count }}</li>
-            {{ end }}
-          </ul>
-        </div>
-      </div>
-    </div>
-
-{{ partial "footer.html" . }}
+<!-- Unused -->

--- a/layouts/download/single.html
+++ b/layouts/download/single.html
@@ -1,42 +1,39 @@
 {{ $.Scratch.Add "additional_head_tags" "<link href=\"/fonts/font-linux.css\" rel=\"stylesheet\">" }}
+
 {{ partial "header.html" . }}
 
-<style>
-.download-os div {
-    display: inline;
-}
-</style>
+{{ .Scratch.Set "sidemenu" true }}
 
 <div class="container">
-  <div class="col-lg-8 col-lg-offset-2">
-    {{ partial "breadcrumb.html" . }}
+	<div class="row">
+		<div class="col-lg-8 col-lg-offset-2 {{ if .Scratch.Get "sidemenu" }}col-md-10 col-sm-9{{ else }}col-sm-12{{ end }}">
+			{{ partial "breadcrumb.html" . }}
 
-    <div class="page-heading">
-      <h1>{{ .Title }}</h1>
-    </div>
-    {{ .Content }}
-  </div>
-  
-  <!--sidebar start-->
-  {{ $currentNode := . }}
-  <div class="col-lg-2">
-    <aside>
-      <nav class="secondary">
-        <!-- sidebar menu start-->
-        <h3>All&nbsp;Platforms</h3>
-        <ul class="list-unstyled side-links list-group">
-        {{ range .Site.Sections.download.Pages }}
-          <li class="list-group-item download-os{{if eq $currentNode . }} active{{end}}">
-          <a href="{{ .RelPermalink }}">
-            {{ .Params.iconhtml | safeHTML }}
-            {{ .Title }}
-          </a>
-          </li>
-        {{end}}
-        </ul>
-      </nav>
-    </aside>
-  </div>
+			<div class="page-heading">
+				<h1>{{ title .Title }}</h1>
+			</div>
+			{{ .Content }}
+		</div>
+
+<!--sidebar start-->
+{{ $currentNode := . }}
+<div class="col-lg-2 col-md-2 col-sm-3 col-sm-offset-0 col-xs-8 col-xs-offset-2">
+	<aside>
+		<nav class="secondary">
+			<!-- sidebar menu start-->
+			<h3>All&nbsp;Platforms</h3>
+			<ul class="list-unstyled side-links list-group download-sidebar">
+				{{ range .Site.Sections.download.Pages }}
+					<li class="list-group-item{{ if  eq $currentNode . }} active{{ end }}"><a href="{{ .RelPermalink }}">{{ .Params.iconhtml | safeHTML }} {{ .Title }}</a></li>
+				{{ end }}
+			</ul>
+			<!-- sidebar menu end-->
+		</nav>
+	</aside>
+</div>
+<!--sidebar end-->
+
+	</div>
 </div>
 
 {{ partial "footer.html" . }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,24 +1,23 @@
 <!--sidebar start-->
 {{ $currentNode := . }}
 {{ if .Scratch.Get "sidemenu" }} 
-<div class="col-lg-2">
+<div class="col-lg-2 col-md-2 col-sm-3 col-sm-offset-0 col-xs-8 col-xs-offset-2">
     <aside>
         <nav class="secondary">
             <!-- sidebar menu start-->
-              {{ $section := .Scratch.Get "sidemenu_section" }}
-              {{ range .Site.Menus.main }}
-                  {{ if eq $section (.Name | lower) }}
-                        {{ if .HasChildren }}
-                            <h3>{{ .Name }}</h3>
-                            <ul class="list-unstyled side-links list-group">
-                                {{ range .Children }}
-                                    <li class="list-group-item{{if $currentNode.IsMenuCurrent "main" . }} active{{end}}"><a href="{{.URL}}"> {{ .Name }} </a> </li>
-                                {{ end }}
-                            </ul>
-                        {{end}}
-                  {{end}}
-              {{end}}
-            </ul>
+            {{ $section := .Scratch.Get "sidemenu_section" }}
+            {{ range .Site.Menus.main }}
+                {{ if eq $section (.Name | lower) }}
+                    {{ if .HasChildren }}
+                        <h3>{{ .Name }}</h3>
+                        <ul class="list-unstyled side-links list-group">
+                            {{ range .Children }}
+                                <li class="list-group-item{{ if $currentNode.IsMenuCurrent "main" . }} active{{ end }}"><a href="{{ .URL }}">{{ .Name }}</a></li>
+                            {{ end }}
+                        </ul>
+                    {{end}}
+                {{end}}
+            {{end}}
             <!-- sidebar menu end-->
         </nav>
     </aside>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -1,30 +1,24 @@
 {{ partial "header.html" .}}
 
-    <!-- Page Header -->
-    <header class="intro-header">
-      <div class="container">
-        <div class="row">
-         <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1 post-full">
-           {{ partial "breadcrumb.html" . }}
-           <h1>{{ title .Title }}</h1>
-           <div class="post-meta">{{ dateFormat .Site.Params.DateForm .Date }}</div>
-         </div>
-        </div>
-      </div>
-    </header>
+{{ .Scratch.Set "sidemenu" false }}
 
-    <!-- Post Content -->
-    <article>
-      <div class="container">
-        <div class="row">
-          <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1 post-full">
-            {{ .Content }}
-            <p>
-            <a href="/post/"><span class="fa fa-arrow-left"></span> Back</a>
-            </p>
-          </div>
-        </div>
-      </div>
-    </article>
+<div class="container">
+  <div class="row">
+    <div class="col-lg-8 col-lg-offset-2 {{ if .Scratch.Get "sidemenu" }}col-md-10 col-sm-9{{ else }}col-sm-12{{ end }} post-full">
+      {{ partial "breadcrumb.html" . }}
+      <header>
+        <h1>{{ title .Title }}</h1>
+        <div class="post-meta">{{ dateFormat .Site.Params.DateForm .Date }}</div>
+      </header>
+
+      <article>
+        {{ .Content }}
+        <p>
+          <a href="/post/"><span class="fa fa-arrow-left"></span> Back</a>
+        </p>
+      </article>
+    </div>
+  </div>
+</div>
 
 {{ partial "footer.html" .}}

--- a/layouts/section/download.html
+++ b/layouts/section/download.html
@@ -14,30 +14,34 @@
 }
 </style>
 <div class="container">
-	<div class="col-lg-8 col-lg-offset-2">
-		{{ partial "breadcrumb.html" . }}
+	<div class="row">
+		<div class="col-lg-8 col-lg-offset-2">
+			{{ partial "breadcrumb.html" . }}
 
-		<div class="page-heading">
-			<h1>{{ .Title }}</h1>
+			<div class="page-heading">
+				<h1>{{ .Title }}</h1>
+			</div>
+
+			<h3>Select your operating system or distribution</h3>
+			<div class="row">
+				<ul class="col-xs-12">
+					{{ range .Data.Pages }}
+						<li class="list-group-item col-md-4 col-xs-12 col-sm-6 download-os">
+							<a href="{{ .RelPermalink }}">
+								{{ .Params.iconhtml | safeHTML }}
+								{{ .Title }}
+							</a>
+						 </li>
+					{{end}}
+				</ul>
+			</div>
+
+			<h3>My operating system or distribution isn't listed!</h3>
+			<p>
+				KiCad is an open source project, download instructions above are provided by the community.
+				If you'd like to provide builds for your operating system or distribution, please submit a <a href="https://github.com/KiCad/kicad-website">pull request.</a>
+			</p>
 		</div>
-
-		<h3>Select your operating system or distribution</h3>
-		<ul class="list-group row">
-			{{ range .Data.Pages }}
-				 <li class="list-group-item col-md-4 col-xs-12 col-sm-6 download-os">
-					<a href="{{ .RelPermalink }}">
-						{{ .Params.iconhtml | safeHTML }}
-						{{ .Title }}
-					</a>
-				 </li>
-			{{end}}
-		</ul>
-
-		<h3>My operating system or distribution isn't listed!</h3>
-		<p>
-			KiCad is an open source project, download instructions above are provided by the community.
-			If you'd like to provide builds for your operating system or distribution, please submit a <a href="https://github.com/KiCad/kicad-website">pull request.</a>
-		</p>
 	</div>
 </div>
 

--- a/layouts/section/made-with-kicad.html
+++ b/layouts/section/made-with-kicad.html
@@ -1,48 +1,52 @@
 {{ partial "header.html" . }}
-<div class="container">
-	{{ $currentNode := . }}
-	{{ .Scratch.Set "sidemenu" false }}
-	{{ .Scratch.Set "sidemenu_section" "discover" }}
-	{{ range .Site.Menus.main }}
-		{{ if eq "discover" (.Name | lower) }}
-			{{ if .HasChildren }}
-				{{ $currentNode.Scratch.Set "sidemenu" true }}
-			{{ end }}
+
+{{ $currentNode := . }}
+{{ .Scratch.Set "sidemenu" false }}
+{{ .Scratch.Set "sidemenu_section" "discover" }}
+{{ range .Site.Menus.main }}
+	{{ if eq "discover" (.Name | lower) }}
+		{{ if .HasChildren }}
+			{{ $currentNode.Scratch.Set "sidemenu" true }}
 		{{ end }}
 	{{ end }}
+{{ end }}
 
-	<!-- Main Content -->
-	<div class="col-lg-8 col-lg-offset-2">
-	        {{ partial "breadcrumb.html" . }}
+<div class="container">
+	<div class="row">
+		<div class="col-lg-8 col-lg-offset-2 {{ if .Scratch.Get "sidemenu" }}col-md-10 col-sm-9{{ else }}col-sm-12{{ end }}">
+			{{ partial "breadcrumb.html" . }}
 
-	        <div class="page-heading">
-	            <h1>{{ replace .Title "-" " " }}</h1>
-		    These are some KiCad designed projects that have been made by users. If you want to
-		    be featured along the other showcases on this page please submit a pull request
-		    <a href="https://github.com/KiCad/kicad-website">on GitHub</a>.
-	        </div>
-	        {{ $paginator := .Paginate (where .Site.Pages "Section" "made-with-kicad") }}
-	        {{ template "_internal/pagination.html" . }}
-	        <hr />
-	        <div class="row">
-	              {{ range $paginator.Pages }}
-	                    <div class="row">
-	                        <div class="col-md-5">
-	                            <img class="img-responsive" src="{{ .Params.projectimage }}" alt="">
-	                        </div>
-	                        <div class="col-md-7">
-	                            <h3>{{ .Title }}</h3>
-	                            <h4>{{ .Params.projectdeveloper }}</h4>
-	                            <p>{{ .Content }}</p>
-	                            <a class="btn btn-primary" href="{{ .Params.projecturl }}">View Project <span class="glyphicon glyphicon-chevron-right"></span></a>
-	                        </div>
-	                    </div>
-	                    <hr />
-	              {{ end }}
-	        </div>
-		{{ template "_internal/pagination.html" . }}
+			<div class="page-heading">
+				<h1>{{ replace .Title "-" " " }}</h1>
+				These are some KiCad designed projects that have been made by users. If you want to
+				be featured along the other showcases on this page please submit a pull request
+				<a href="https://github.com/KiCad/kicad-website">on GitHub</a>.
+			</div>
+
+			{{ $paginator := .Paginate (where .Site.Pages "Section" "made-with-kicad") }}
+			{{ template "_internal/pagination.html" . }}
+			<hr />
+			<div class="row">
+				{{ range $paginator.Pages }}
+					<div class="row">
+						<div class="col-md-5">
+							<img class="img-responsive" src="{{ .Params.projectimage }}">
+						</div>
+						<div class="col-md-7">
+							<h3>{{ .Title }}</h3>
+							<h4>{{ .Params.projectdeveloper }}</h4>
+							<p>{{ .Content }}</p>
+							<a class="btn btn-primary" href="{{ .Params.projecturl }}">View Project <span class="glyphicon glyphicon-chevron-right"></span></a>
+						</div>
+					</div>
+					<hr />
+				{{ end }}
+			</div>
+			{{ template "_internal/pagination.html" . }}
+		</div>
+
+		{{ partial "sidebar.html" . }}
 	</div>
-	{{ partial "sidebar.html" . }}
 </div>
 
 {{ partial "footer.html" . }}

--- a/layouts/section/post.html
+++ b/layouts/section/post.html
@@ -1,25 +1,24 @@
 {{ partial "header.html" . }}
 
-    <!-- Main Content -->
-    <div class="container">
-      <div class="row">
-        <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
-          {{ partial "breadcrumb.html" . }}
-          <!--div class="post-preview-intro">
-            These posts are updated every now and then. Watch this space for release notes and other useful news.
-          </div>
-          <hr-->
-          
-          {{ range .Paginator.Pages }}
-              {{ .Render "summary" }}
-          {{ end }}
-          {{ template "_internal/pagination.html" . }}
-          
-          <p class="post-preview-intro" style="text-align: center">
-            For even fresher news, look at the <a href="https://lists.launchpad.net/kicad-developers/">kicad-developers mailing-list</a>.
-          </p>
-        </div>
-      </div>
-    </div>
+{{ .Scratch.Set "sidemenu" false }}
+
+<div class="container">
+	<div class="row">
+		<div class="col-lg-8 col-lg-offset-2 {{ if .Scratch.Get "sidemenu" }}col-md-10 col-sm-9{{ else }}col-sm-12{{ end }}">
+			{{ partial "breadcrumb.html" . }}
+
+			{{ range .Paginator.Pages }}
+				{{ .Render "summary" }}
+			{{ end }}
+			{{ template "_internal/pagination.html" . }}
+
+			<p class="post-preview-intro" style="text-align: center">
+				For even fresher news, look at the <a href="https://lists.launchpad.net/kicad-developers/">kicad-developers mailing-list</a>.
+			</p>
+		</div>
+	</div>
+
+	{{ partial "sidebar.html" . }}
+</div>
 
 {{ partial "footer.html" . }}

--- a/static/css/kicad.css
+++ b/static/css/kicad.css
@@ -358,3 +358,8 @@ nav.secondary .list-group-item {
 nav.secondary a {
     display: block;
 }
+
+/* download page specifics */
+.download-sidebar div { /* font-awesome icon */
+    display: inline;
+}


### PR DESCRIPTION
Not a lot changes, this is mostly polishing.

- The code for similar layouts is now more similar, this should help for further evolutions.
- Ensure the 'row' div is used for every container. This helped fix the extra padding on /download.
- Only when the main menu is collapsed will sidebars be pushed after the content.
- Give more love to pages like /discover/

Preview: http://dallens.fr/