### PR TITLE
mention the ".adoc" file format

### DIFF
--- a/content/help/file-formats.adoc
+++ b/content/help/file-formats.adoc
@@ -96,7 +96,7 @@ link:http://www.freerouting.net/[FreeRouting]).
 
 === Other formats used by the KiCad project
 
-* `.pdf`: All the help documentation intended to be read by KiCad users is in "'.pdf'" format.
+* `.pdf`: All the help documentation intended to be read by KiCad users is in `.pdf` format.
 
 * EDIF (_Electronic Design Interchange Format_) netlist format.
 link:https://en.wikipedia.org/wiki/EDIF[Wikipedia]
@@ -105,3 +105,7 @@ link:https://en.wikipedia.org/wiki/EDIF[Wikipedia]
 good format for posting a section of a schematic (or a section of a PCB layout) to a web page, so people can see it immediately
 in a web browser without manually "downloading" or "installing" anything.
       
+* `.adoc`: All those `.pdf` files and `.html` files are automatically generated from source files in link:http://en.wikipedia.org/wiki/AsciiDoc[AsciiDoc format].
+The link:http://github.com/KiCad/kicad-doc/blob/master/doc_alternatives/README.adoc["KiCad Documentation Status Report"]
+persuaded us to switch from `.odt` format to `.adoc` on 2015-02-09.
+A link:http://en.wikipedia.org/wiki/Lightweight_markup_language[lightweight markup language] is easy to update with a wider variety of editing tools, and then much easier for our translators to see what changed and make corresponding improvements in other languages.


### PR DESCRIPTION
I'm surprised that this list of file formats doesn't yet mention ".adoc", the format that this list itself is in.
(See http://github.com/KiCad/kicad-website/pull/51 for previous discussion).