### PR TITLE
Add details to the migration procedure

### DIFF
--- a/content/help/migration-from-old-stable.adoc
+++ b/content/help/migration-from-old-stable.adoc
@@ -10,9 +10,11 @@ There is likely to be some issues if you want to migrate designs from the old st
 
 == Layernames are translated
 
-This issue arises if you used the old stable with another language other than English. Below is the key for renaming the layers manually, showing how the layernames were in Italian and French. You will not only need to replace the layers list, but also search and replace on all the names in the file.
+This issue arises if you used the old stable version with a language other than English.
 
-==== English
+You need to edit all `.kicad_pcb` files with a text editor (notepad, ...) and change the layer names from Italian/French to their English counterparts. Below is the correspondance of the layer names. Caution: there are more instances to replace than just the layer list. Be sure that you don't miss any.
+
+==== New English names
 ----
 (layers
   (15 F.Cu signal)
@@ -33,7 +35,7 @@ This issue arises if you used the old stable with another language other than En
 )
 ----
 
-==== Italian
+==== Obsolete Italian names
 ----
 (layers
   (15 Rame.Fronte signal)
@@ -54,7 +56,7 @@ This issue arises if you used the old stable with another language other than En
 )
 ----
 
-==== French
+==== Obsolete French names
 ----
 (layers
   (15 Front signal)


### PR DESCRIPTION
Tried to improve the explanation. Added the crucial info that you need a text editor for .kicad_pcb files. Changed the section titles for clarity.

Prompted by the following question:
https://forum.kicad.info/t/instaling-version-4-0-1-trouble/1983