### PR TITLE
Sort all entries on Documentation alphabetical, adding links for available German documentation

### DIFF
--- a/content/help/documentation.adoc
+++ b/content/help/documentation.adoc
@@ -50,10 +50,10 @@ Schematic editor and component editor.
 |Language |Format
 
 |English | link:http://docs.kicad-pcb.org/en/eeschema.html[HTML] link:http://docs.kicad-pcb.org/en/eeschema.pdf[PDF] link:http://docs.kicad-pcb.org/en/eeschema.epub[ePub]
-|Polski | link:http://docs.kicad-pcb.org/pl/eeschema.html[HTML] link:http://docs.kicad-pcb.org/pl/eeschema.pdf[PDF] link:http://docs.kicad-pcb.org/pl/eeschema.epub[ePub]
-|日本語 | link:http://docs.kicad-pcb.org/ja/eeschema.html[HTML] link:http://docs.kicad-pcb.org/ja/eeschema.pdf[PDF] link:http://docs.kicad-pcb.org/ja/eeschema.epub[ePub]
-|Italiano | link:http://docs.kicad-pcb.org/it/eeschema.html[HTML] link:http://docs.kicad-pcb.org/it/eeschema.pdf[PDF] link:http://docs.kicad-pcb.org/it/eeschema.epub[ePub]
 |Español | link:http://docs.kicad-pcb.org/es/eeschema.html[HTML] link:http://docs.kicad-pcb.org/es/eeschema.pdf[PDF] link:http://docs.kicad-pcb.org/es/eeschema.epub[ePub]
+|Italiano | link:http://docs.kicad-pcb.org/it/eeschema.html[HTML] link:http://docs.kicad-pcb.org/it/eeschema.pdf[PDF] link:http://docs.kicad-pcb.org/it/eeschema.epub[ePub]
+|日本語 | link:http://docs.kicad-pcb.org/ja/eeschema.html[HTML] link:http://docs.kicad-pcb.org/ja/eeschema.pdf[PDF] link:http://docs.kicad-pcb.org/ja/eeschema.epub[ePub]
+|Polski | link:http://docs.kicad-pcb.org/pl/eeschema.html[HTML] link:http://docs.kicad-pcb.org/pl/eeschema.pdf[PDF] link:http://docs.kicad-pcb.org/pl/eeschema.epub[ePub]
 |===
 
 

--- a/content/help/documentation.adoc
+++ b/content/help/documentation.adoc
@@ -19,6 +19,7 @@ Essential and concise guide to mastering KiCad for the successful development of
 |===
 |Language |Format
 
+|Deutsch | link:http://docs.kicad-pcb.org/de/getting_started_in_kicad.html[HTML] link:http://docs.kicad-pcb.org/de/getting_started_in_kicad.pdf[PDF] link:http://docs.kicad-pcb.org/de/getting_started_in_kicad.epub[ePub]
 |English | link:http://docs.kicad-pcb.org/en/getting_started_in_kicad.html[HTML] link:http://docs.kicad-pcb.org/en/getting_started_in_kicad.pdf[PDF] link:http://docs.kicad-pcb.org/en/getting_started_in_kicad.epub[ePub]
 |Español | link:http://docs.kicad-pcb.org/es/getting_started_in_kicad.html[HTML] link:http://docs.kicad-pcb.org/es/getting_started_in_kicad.pdf[PDF] link:http://docs.kicad-pcb.org/es/getting_started_in_kicad.epub[ePub]
 |Français | link:http://docs.kicad-pcb.org/fr/getting_started_in_kicad.html[HTML] link:http://docs.kicad-pcb.org/fr/getting_started_in_kicad.pdf[PDF] link:http://docs.kicad-pcb.org/fr/getting_started_in_kicad.epub[ePub]
@@ -49,6 +50,7 @@ Schematic editor and component editor.
 |===
 |Language |Format
 
+|Deutsch | link:http://docs.kicad-pcb.org/de/eeschema.html[HTML] link:http://docs.kicad-pcb.org/de/eeschema.pdf[PDF] link:http://docs.kicad-pcb.org/de/eeschema.epub[ePub]
 |English | link:http://docs.kicad-pcb.org/en/eeschema.html[HTML] link:http://docs.kicad-pcb.org/en/eeschema.pdf[PDF] link:http://docs.kicad-pcb.org/en/eeschema.epub[ePub]
 |Español | link:http://docs.kicad-pcb.org/es/eeschema.html[HTML] link:http://docs.kicad-pcb.org/es/eeschema.pdf[PDF] link:http://docs.kicad-pcb.org/es/eeschema.epub[ePub]
 |Italiano | link:http://docs.kicad-pcb.org/it/eeschema.html[HTML] link:http://docs.kicad-pcb.org/it/eeschema.pdf[PDF] link:http://docs.kicad-pcb.org/it/eeschema.epub[ePub]
@@ -77,6 +79,7 @@ Footprint selector helper (always run from Eeschema).
 |===
 |Language |Format
 
+|Deutsch | link:http://docs.kicad-pcb.org/de/cvpcb.html[HTML] link:http://docs.kicad-pcb.org/de/cvpcb.pdf[PDF] link:http://docs.kicad-pcb.org/de/cvpcb.epub[ePub]
 |English | link:http://docs.kicad-pcb.org/en/cvpcb.html[HTML] link:http://docs.kicad-pcb.org/en/cvpcb.pdf[PDF] link:http://docs.kicad-pcb.org/en/cvpcb.epub[ePub]
 |Español | link:http://docs.kicad-pcb.org/es/cvpcb.html[HTML] link:http://docs.kicad-pcb.org/es/cvpcb.pdf[PDF] link:http://docs.kicad-pcb.org/es/cvpcb.epub[ePub]
 |Italiano | link:http://docs.kicad-pcb.org/it/cvpcb.html[HTML] link:http://docs.kicad-pcb.org/it/cvpcb.pdf[PDF] link:http://docs.kicad-pcb.org/it/cvpcb.epub[ePub]
@@ -92,6 +95,7 @@ Gerber viewer
 |===
 |Language |Format
 
+|Deutsch | link:http://docs.kicad-pcb.org/de/gerbview.html[HTML] link:http://docs.kicad-pcb.org/de/gerbview.pdf[PDF] link:http://docs.kicad-pcb.org/de/gerbview.epub[ePub]
 |English | link:http://docs.kicad-pcb.org/en/gerbview.html[HTML] link:http://docs.kicad-pcb.org/en/gerbview.pdf[PDF] link:http://docs.kicad-pcb.org/en/gerbview.epub[ePub]
 |Italiano | link:http://docs.kicad-pcb.org/it/gerbview.html[HTML] link:http://docs.kicad-pcb.org/it/gerbview.pdf[PDF] link:http://docs.kicad-pcb.org/it/gerbview.epub[ePub]
 |日本語 | link:http://docs.kicad-pcb.org/ja/gerbview.html[HTML] link:http://docs.kicad-pcb.org/ja/gerbview.pdf[PDF] link:http://docs.kicad-pcb.org/ja/gerbview.epub[ePub]

--- a/content/help/documentation.adoc
+++ b/content/help/documentation.adoc
@@ -108,9 +108,9 @@ Page Layout Editor.
 |Language |Format
 
 |English | link:http://docs.kicad-pcb.org/en/pl_editor.html[HTML] link:http://docs.kicad-pcb.org/en/pl_editor.pdf[PDF] link:http://docs.kicad-pcb.org/en/pl_editor.epub[ePub]
-|Polski | link:http://docs.kicad-pcb.org/pl/pl_editor.html[HTML] link:http://docs.kicad-pcb.org/pl/pl_editor.pdf[PDF] link:http://docs.kicad-pcb.org/pl/pl_editor.epub[ePub]
-|日本語 | link:http://docs.kicad-pcb.org/ja/pl_editor.html[HTML] link:http://docs.kicad-pcb.org/ja/pl_editor.pdf[PDF] link:http://docs.kicad-pcb.org/ja/pl_editor.epub[ePub]
 |Italiano | link:http://docs.kicad-pcb.org/it/pl_editor.html[HTML] link:http://docs.kicad-pcb.org/it/pl_editor.pdf[PDF] link:http://docs.kicad-pcb.org/it/pl_editor.epub[ePub]
+|日本語 | link:http://docs.kicad-pcb.org/ja/pl_editor.html[HTML] link:http://docs.kicad-pcb.org/ja/pl_editor.pdf[PDF] link:http://docs.kicad-pcb.org/ja/pl_editor.epub[ePub]
+|Polski | link:http://docs.kicad-pcb.org/pl/pl_editor.html[HTML] link:http://docs.kicad-pcb.org/pl/pl_editor.pdf[PDF] link:http://docs.kicad-pcb.org/pl/pl_editor.epub[ePub]
 |===
 
 === IDF Exporter

--- a/content/help/documentation.adoc
+++ b/content/help/documentation.adoc
@@ -93,9 +93,9 @@ Gerber viewer
 |Language |Format
 
 |English | link:http://docs.kicad-pcb.org/en/gerbview.html[HTML] link:http://docs.kicad-pcb.org/en/gerbview.pdf[PDF] link:http://docs.kicad-pcb.org/en/gerbview.epub[ePub]
-|Polski | link:http://docs.kicad-pcb.org/pl/gerbview.html[HTML] link:http://docs.kicad-pcb.org/pl/gerbview.pdf[PDF] link:http://docs.kicad-pcb.org/pl/gerbview.epub[ePub]
-|日本語 | link:http://docs.kicad-pcb.org/ja/gerbview.html[HTML] link:http://docs.kicad-pcb.org/ja/gerbview.pdf[PDF] link:http://docs.kicad-pcb.org/ja/gerbview.epub[ePub]
 |Italiano | link:http://docs.kicad-pcb.org/it/gerbview.html[HTML] link:http://docs.kicad-pcb.org/it/gerbview.pdf[PDF] link:http://docs.kicad-pcb.org/it/gerbview.epub[ePub]
+|日本語 | link:http://docs.kicad-pcb.org/ja/gerbview.html[HTML] link:http://docs.kicad-pcb.org/ja/gerbview.pdf[PDF] link:http://docs.kicad-pcb.org/ja/gerbview.epub[ePub]
+|Polski | link:http://docs.kicad-pcb.org/pl/gerbview.html[HTML] link:http://docs.kicad-pcb.org/pl/gerbview.pdf[PDF] link:http://docs.kicad-pcb.org/pl/gerbview.epub[ePub]
 |===
 
 == Utilities

--- a/content/help/documentation.adoc
+++ b/content/help/documentation.adoc
@@ -35,10 +35,10 @@ Project manager window.
 |Language |Format
 
 |English | link:http://docs.kicad-pcb.org/en/kicad.html[HTML] link:http://docs.kicad-pcb.org/en/kicad.pdf[PDF] link:http://docs.kicad-pcb.org/en/kicad.epub[ePub]
-|Polski | link:http://docs.kicad-pcb.org/pl/kicad.html[HTML] link:http://docs.kicad-pcb.org/pl/kicad.pdf[PDF] link:http://docs.kicad-pcb.org/pl/kicad.epub[ePub]
-|日本語 | link:http://docs.kicad-pcb.org/ja/kicad.html[HTML] link:http://docs.kicad-pcb.org/ja/kicad.pdf[PDF] link:http://docs.kicad-pcb.org/ja/kicad.epub[ePub]
-|Italiano | link:http://docs.kicad-pcb.org/it/kicad.html[HTML] link:http://docs.kicad-pcb.org/it/kicad.pdf[PDF] link:http://docs.kicad-pcb.org/it/kicad.epub[ePub]
 |Español | link:http://docs.kicad-pcb.org/es/kicad.html[HTML] link:http://docs.kicad-pcb.org/es/kicad.pdf[PDF] link:http://docs.kicad-pcb.org/es/kicad.epub[ePub]
+|Italiano | link:http://docs.kicad-pcb.org/it/kicad.html[HTML] link:http://docs.kicad-pcb.org/it/kicad.pdf[PDF] link:http://docs.kicad-pcb.org/it/kicad.epub[ePub]
+|日本語 | link:http://docs.kicad-pcb.org/ja/kicad.html[HTML] link:http://docs.kicad-pcb.org/ja/kicad.pdf[PDF] link:http://docs.kicad-pcb.org/ja/kicad.epub[ePub]
+|Polski | link:http://docs.kicad-pcb.org/pl/kicad.html[HTML] link:http://docs.kicad-pcb.org/pl/kicad.pdf[PDF] link:http://docs.kicad-pcb.org/pl/kicad.epub[ePub]
 |===
 
 

--- a/content/help/documentation.adoc
+++ b/content/help/documentation.adoc
@@ -65,9 +65,9 @@ Circuit board layout editor and footprint editor.
 |Language |Format
 
 |English | link:http://docs.kicad-pcb.org/en/pcbnew.html[HTML] link:http://docs.kicad-pcb.org/en/pcbnew.pdf[PDF] link:http://docs.kicad-pcb.org/en/pcbnew.epub[ePub]
-|Polski | link:http://docs.kicad-pcb.org/pl/pcbnew.html[HTML] link:http://docs.kicad-pcb.org/pl/pcbnew.pdf[PDF] link:http://docs.kicad-pcb.org/pl/pcbnew.epub[ePub]
-|日本語 | link:http://docs.kicad-pcb.org/ja/pcbnew.html[HTML] link:http://docs.kicad-pcb.org/ja/pcbnew.pdf[PDF] link:http://docs.kicad-pcb.org/ja/pcbnew.epub[ePub]
 |Italiano | link:http://docs.kicad-pcb.org/it/pcbnew.html[HTML] link:http://docs.kicad-pcb.org/it/pcbnew.pdf[PDF] link:http://docs.kicad-pcb.org/it/pcbnew.epub[ePub]
+|日本語 | link:http://docs.kicad-pcb.org/ja/pcbnew.html[HTML] link:http://docs.kicad-pcb.org/ja/pcbnew.pdf[PDF] link:http://docs.kicad-pcb.org/ja/pcbnew.epub[ePub]
+|Polski | link:http://docs.kicad-pcb.org/pl/pcbnew.html[HTML] link:http://docs.kicad-pcb.org/pl/pcbnew.pdf[PDF] link:http://docs.kicad-pcb.org/pl/pcbnew.epub[ePub]
 |===
 
 == CvPcb

--- a/content/help/documentation.adoc
+++ b/content/help/documentation.adoc
@@ -78,10 +78,10 @@ Footprint selector helper (always run from Eeschema).
 |Language |Format
 
 |English | link:http://docs.kicad-pcb.org/en/cvpcb.html[HTML] link:http://docs.kicad-pcb.org/en/cvpcb.pdf[PDF] link:http://docs.kicad-pcb.org/en/cvpcb.epub[ePub]
-|Polski | link:http://docs.kicad-pcb.org/pl/cvpcb.html[HTML] link:http://docs.kicad-pcb.org/pl/cvpcb.pdf[PDF] link:http://docs.kicad-pcb.org/pl/cvpcb.epub[ePub]
-|日本語 | link:http://docs.kicad-pcb.org/ja/cvpcb.html[HTML] link:http://docs.kicad-pcb.org/ja/cvpcb.pdf[PDF] link:http://docs.kicad-pcb.org/ja/cvpcb.epub[ePub]
-|Italiano | link:http://docs.kicad-pcb.org/it/cvpcb.html[HTML] link:http://docs.kicad-pcb.org/it/cvpcb.pdf[PDF] link:http://docs.kicad-pcb.org/it/cvpcb.epub[ePub]
 |Español | link:http://docs.kicad-pcb.org/es/cvpcb.html[HTML] link:http://docs.kicad-pcb.org/es/cvpcb.pdf[PDF] link:http://docs.kicad-pcb.org/es/cvpcb.epub[ePub]
+|Italiano | link:http://docs.kicad-pcb.org/it/cvpcb.html[HTML] link:http://docs.kicad-pcb.org/it/cvpcb.pdf[PDF] link:http://docs.kicad-pcb.org/it/cvpcb.epub[ePub]
+|日本語 | link:http://docs.kicad-pcb.org/ja/cvpcb.html[HTML] link:http://docs.kicad-pcb.org/ja/cvpcb.pdf[PDF] link:http://docs.kicad-pcb.org/ja/cvpcb.epub[ePub]
+|Polski | link:http://docs.kicad-pcb.org/pl/cvpcb.html[HTML] link:http://docs.kicad-pcb.org/pl/cvpcb.pdf[PDF] link:http://docs.kicad-pcb.org/pl/cvpcb.epub[ePub]
 |===
 
 

--- a/content/help/documentation.adoc
+++ b/content/help/documentation.adoc
@@ -20,11 +20,11 @@ Essential and concise guide to mastering KiCad for the successful development of
 |Language |Format
 
 |English | link:http://docs.kicad-pcb.org/en/getting_started_in_kicad.html[HTML] link:http://docs.kicad-pcb.org/en/getting_started_in_kicad.pdf[PDF] link:http://docs.kicad-pcb.org/en/getting_started_in_kicad.epub[ePub]
-|Polski | link:http://docs.kicad-pcb.org/pl/getting_started_in_kicad.html[HTML] link:http://docs.kicad-pcb.org/pl/getting_started_in_kicad.pdf[PDF] link:http://docs.kicad-pcb.org/pl/getting_started_in_kicad.epub[ePub]
-|日本語 | link:http://docs.kicad-pcb.org/ja/getting_started_in_kicad.html[HTML] link:http://docs.kicad-pcb.org/ja/getting_started_in_kicad.pdf[PDF] link:http://docs.kicad-pcb.org/ja/getting_started_in_kicad.epub[ePub]
-|Italiano | link:http://docs.kicad-pcb.org/it/getting_started_in_kicad.html[HTML] link:http://docs.kicad-pcb.org/it/getting_started_in_kicad.pdf[PDF] link:http://docs.kicad-pcb.org/it/getting_started_in_kicad.epub[ePub]
-|Français | link:http://docs.kicad-pcb.org/fr/getting_started_in_kicad.html[HTML] link:http://docs.kicad-pcb.org/fr/getting_started_in_kicad.pdf[PDF] link:http://docs.kicad-pcb.org/fr/getting_started_in_kicad.epub[ePub]
 |Español | link:http://docs.kicad-pcb.org/es/getting_started_in_kicad.html[HTML] link:http://docs.kicad-pcb.org/es/getting_started_in_kicad.pdf[PDF] link:http://docs.kicad-pcb.org/es/getting_started_in_kicad.epub[ePub]
+|Français | link:http://docs.kicad-pcb.org/fr/getting_started_in_kicad.html[HTML] link:http://docs.kicad-pcb.org/fr/getting_started_in_kicad.pdf[PDF] link:http://docs.kicad-pcb.org/fr/getting_started_in_kicad.epub[ePub]
+|Italiano | link:http://docs.kicad-pcb.org/it/getting_started_in_kicad.html[HTML] link:http://docs.kicad-pcb.org/it/getting_started_in_kicad.pdf[PDF] link:http://docs.kicad-pcb.org/it/getting_started_in_kicad.epub[ePub]
+|日本語 | link:http://docs.kicad-pcb.org/ja/getting_started_in_kicad.html[HTML] link:http://docs.kicad-pcb.org/ja/getting_started_in_kicad.pdf[PDF] link:http://docs.kicad-pcb.org/ja/getting_started_in_kicad.epub[ePub]
+|Polski | link:http://docs.kicad-pcb.org/pl/getting_started_in_kicad.html[HTML] link:http://docs.kicad-pcb.org/pl/getting_started_in_kicad.pdf[PDF] link:http://docs.kicad-pcb.org/pl/getting_started_in_kicad.epub[ePub]
 |===
 
 == KiCad
@@ -121,7 +121,7 @@ Exports an IDFv3 compliant board (.emn) and library (.emp) file for communicatin
 |Language |Format
 
 |English | link:http://docs.kicad-pcb.org/en/idf_exporter.html[HTML] link:http://docs.kicad-pcb.org/en/idf_exporter.pdf[PDF] link:http://docs.kicad-pcb.org/en/idf_exporter.epub[ePub]
-|Polski | link:http://docs.kicad-pcb.org/pl/idf_exporter.html[HTML] link:http://docs.kicad-pcb.org/pl/idf_exporter.pdf[PDF] link:http://docs.kicad-pcb.org/pl/idf_exporter.epub[ePub]
-|日本語 | link:http://docs.kicad-pcb.org/ja/idf_exporter.html[HTML] link:http://docs.kicad-pcb.org/ja/idf_exporter.pdf[PDF] link:http://docs.kicad-pcb.org/ja/idf_exporter.epub[ePub]
 |Italiano | link:http://docs.kicad-pcb.org/it/idf_exporter.html[HTML] link:http://docs.kicad-pcb.org/it/idf_exporter.pdf[PDF] link:http://docs.kicad-pcb.org/it/idf_exporter.epub[ePub]
+|日本語 | link:http://docs.kicad-pcb.org/ja/idf_exporter.html[HTML] link:http://docs.kicad-pcb.org/ja/idf_exporter.pdf[PDF] link:http://docs.kicad-pcb.org/ja/idf_exporter.epub[ePub]
+|Polski | link:http://docs.kicad-pcb.org/pl/idf_exporter.html[HTML] link:http://docs.kicad-pcb.org/pl/idf_exporter.pdf[PDF] link:http://docs.kicad-pcb.org/pl/idf_exporter.epub[ePub]
 |===


### PR DESCRIPTION
I sorted all entries on the Documentation website in a alphabetical order as people will find the searched item easier. And finally adding the available German manuals.