### PR TITLE
Improve TOC styling to separate it from page contents

### DIFF
--- a/static/css/kicad.css
+++ b/static/css/kicad.css
@@ -363,3 +363,27 @@ nav.secondary a {
 .download-sidebar div { /* font-awesome icon */
     display: inline;
 }
+
+#toc {
+    font-size: 15px;
+    border: solid 1px #ccc;
+    background: #f5f5f5;
+    display: table;
+    padding: 12px;
+}
+#toc ul {
+    list-style-type: decimal;
+    padding-left: 20px;
+    margin: 0;
+}
+#toc a {
+    display: block;
+    padding-right: 20px;
+}
+#toc li {
+    padding: 0;
+}
+#toc ul ul, #toc ul ul ul {
+    font-size: smaller;
+    list-style-type: lower-roman;
+}

--- a/static/css/kicad.css
+++ b/static/css/kicad.css
@@ -366,7 +366,7 @@ nav.secondary a {
 
 #toc {
     font-size: 15px;
-    border: solid 1px #ccc;
+    border-radius: 4px;
     background: #f5f5f5;
     display: table;
     padding: 12px;
@@ -383,7 +383,10 @@ nav.secondary a {
 #toc li {
     padding: 0;
 }
-#toc ul ul, #toc ul ul ul {
-    font-size: smaller;
+#toc ul ul {
+    font-size: 13px;
     list-style-type: lower-roman;
+}
+#toc ul ul ul {
+    list-style-type: none;
 }


### PR DESCRIPTION
Improve table of contents styling to separate it from page contents.

There might be an issue with the numerals. I don't understand how the bullets of `<li>` containing a second-level `<ul>` are hidden in the current website. I can't reproduce that locally.
Example: why do first-level bullets stop after "Utilities"? http://kicad-pcb.org/help/documentation/