### PR TITLE
Add links to FR docs, more concise introduction

### DIFF
--- a/content/help/documentation.adoc
+++ b/content/help/documentation.adoc
@@ -8,12 +8,12 @@ weight = 10
 :toc: macro 
 :toc-title:
 
-KiCad's documentation is split up into a document per application for convenience. Documents are available in HTML, PDF and ePub along with a few language options where they have been translated.
+One document per application, available in HTML (online), PDF and ePub with many translations.
 
 toc::[]
 
 == Getting Started
-Essential and concise guide to mastering KiCad for the successful development of sophisticated electronic printed circuit boards.
+Essential and concise guide to mastering KiCad.
 
 [role="table table-striped table-condensed"]
 |===
@@ -38,6 +38,7 @@ Project manager window.
 |English | link:http://docs.kicad-pcb.org/en/kicad.html[HTML] link:http://docs.kicad-pcb.org/en/kicad.pdf[PDF] link:http://docs.kicad-pcb.org/en/kicad.epub[ePub]
 |Deutsch | link:http://docs.kicad-pcb.org/de/kicad.html[HTML] link:http://docs.kicad-pcb.org/de/kicad.pdf[PDF] link:http://docs.kicad-pcb.org/de/kicad.epub[ePub]
 |Español | link:http://docs.kicad-pcb.org/es/kicad.html[HTML] link:http://docs.kicad-pcb.org/es/kicad.pdf[PDF] link:http://docs.kicad-pcb.org/es/kicad.epub[ePub]
+|Français | link:http://docs.kicad-pcb.org/fr/kicad.html[HTML] link:http://docs.kicad-pcb.org/fr/kicad.pdf[PDF] link:http://docs.kicad-pcb.org/fr/kicad.epub[ePub]
 |Italiano | link:http://docs.kicad-pcb.org/it/kicad.html[HTML] link:http://docs.kicad-pcb.org/it/kicad.pdf[PDF] link:http://docs.kicad-pcb.org/it/kicad.epub[ePub]
 |日本語 | link:http://docs.kicad-pcb.org/ja/kicad.html[HTML] link:http://docs.kicad-pcb.org/ja/kicad.pdf[PDF] link:http://docs.kicad-pcb.org/ja/kicad.epub[ePub]
 |Polski | link:http://docs.kicad-pcb.org/pl/kicad.html[HTML] link:http://docs.kicad-pcb.org/pl/kicad.pdf[PDF] link:http://docs.kicad-pcb.org/pl/kicad.epub[ePub]
@@ -54,6 +55,7 @@ Schematic editor and component editor.
 |English | link:http://docs.kicad-pcb.org/en/eeschema.html[HTML] link:http://docs.kicad-pcb.org/en/eeschema.pdf[PDF] link:http://docs.kicad-pcb.org/en/eeschema.epub[ePub]
 |Deutsch | link:http://docs.kicad-pcb.org/de/eeschema.html[HTML] link:http://docs.kicad-pcb.org/de/eeschema.pdf[PDF] link:http://docs.kicad-pcb.org/de/eeschema.epub[ePub]
 |Español | link:http://docs.kicad-pcb.org/es/eeschema.html[HTML] link:http://docs.kicad-pcb.org/es/eeschema.pdf[PDF] link:http://docs.kicad-pcb.org/es/eeschema.epub[ePub]
+|Français | link:http://docs.kicad-pcb.org/fr/eeschema.html[HTML] link:http://docs.kicad-pcb.org/fr/eeschema.pdf[PDF] link:http://docs.kicad-pcb.org/fr/eeschema.epub[ePub]
 |Italiano | link:http://docs.kicad-pcb.org/it/eeschema.html[HTML] link:http://docs.kicad-pcb.org/it/eeschema.pdf[PDF] link:http://docs.kicad-pcb.org/it/eeschema.epub[ePub]
 |日本語 | link:http://docs.kicad-pcb.org/ja/eeschema.html[HTML] link:http://docs.kicad-pcb.org/ja/eeschema.pdf[PDF] link:http://docs.kicad-pcb.org/ja/eeschema.epub[ePub]
 |Polski | link:http://docs.kicad-pcb.org/pl/eeschema.html[HTML] link:http://docs.kicad-pcb.org/pl/eeschema.pdf[PDF] link:http://docs.kicad-pcb.org/pl/eeschema.epub[ePub]
@@ -84,6 +86,7 @@ Footprint selector helper (always run from Eeschema).
 |English | link:http://docs.kicad-pcb.org/en/cvpcb.html[HTML] link:http://docs.kicad-pcb.org/en/cvpcb.pdf[PDF] link:http://docs.kicad-pcb.org/en/cvpcb.epub[ePub]
 |Deutsch | link:http://docs.kicad-pcb.org/de/cvpcb.html[HTML] link:http://docs.kicad-pcb.org/de/cvpcb.pdf[PDF] link:http://docs.kicad-pcb.org/de/cvpcb.epub[ePub]
 |Español | link:http://docs.kicad-pcb.org/es/cvpcb.html[HTML] link:http://docs.kicad-pcb.org/es/cvpcb.pdf[PDF] link:http://docs.kicad-pcb.org/es/cvpcb.epub[ePub]
+|Français | link:http://docs.kicad-pcb.org/fr/cvpcb.html[HTML] link:http://docs.kicad-pcb.org/fr/cvpcb.pdf[PDF] link:http://docs.kicad-pcb.org/fr/cvpcb.epub[ePub]
 |Italiano | link:http://docs.kicad-pcb.org/it/cvpcb.html[HTML] link:http://docs.kicad-pcb.org/it/cvpcb.pdf[PDF] link:http://docs.kicad-pcb.org/it/cvpcb.epub[ePub]
 |日本語 | link:http://docs.kicad-pcb.org/ja/cvpcb.html[HTML] link:http://docs.kicad-pcb.org/ja/cvpcb.pdf[PDF] link:http://docs.kicad-pcb.org/ja/cvpcb.epub[ePub]
 |Polski | link:http://docs.kicad-pcb.org/pl/cvpcb.html[HTML] link:http://docs.kicad-pcb.org/pl/cvpcb.pdf[PDF] link:http://docs.kicad-pcb.org/pl/cvpcb.epub[ePub]


### PR DESCRIPTION
Add links to the current French translations of the documentation.
Condense the introductory text to have less things blocking users from getting to the actual doc.