### PR TITLE
Improve OS X and Windows download page

### DIFF
--- a/content/download/osx.adoc
+++ b/content/download/osx.adoc
@@ -4,27 +4,23 @@ iconhtml = "<div><i class='fa fa-apple'></i></div>"
 weight = 2
 +++
 
-=== 4.0.1 Stable Release
+KiCad for OS X is available as two disk images (dmg). You usually want to install both.
+
+KiCad is supported on OS X 10.7 through OS X 10.11.
+
+- *KiCad main package* contains the KiCad suite, documentation, schematic symbols, translations, and some templates. It gets footprints from the internet.
+
+- *KiCad extras* contains the footprints and all the instructions you need for making printed circuit board layouts while offline.
+
+=== Stable Release
 
 Current Version: *4.0.1*
 
-KiCad for OS X is available as two disk image (dmg) files.
-
-The kicad.dmg file includes the KiCad suite, documentation, schematic symbols, and some templates.  It gets footprints from the internet.
-
-kicad-extras.dmg contains the footprints and all the instructions you need for making printed circuit board layouts while offline.
-
- - http://downloads.kicad-pcb.org/osx/stable/kicad-4.0.1.dmg[KiCad main package]
- - http://downloads.kicad-pcb.org/osx/stable/kicad-extras-4.0.1.dmg[KiCad extras]
-
-You usually want to install both disk images.
+- http://downloads.kicad-pcb.org/osx/stable/kicad-4.0.1.dmg[[fa fa-download]#&nbsp;# KiCad main package]
+- http://downloads.kicad-pcb.org/osx/stable/kicad-extras-4.0.1.dmg[[fa fa-download]#&nbsp;# KiCad extras]
 
 === Nightly Development Builds
-Nightly development builds of KiCad for OS X are available at http://downloads.kicad-pcb.org/osx/, built by Adam Wolf.  KiCad is supported on OS X 10.7 through OS X 10.11.
 
-These are the "nightly" builds.  This means they are snapshots of the codebase at that time, and may contain even more bugs than usual, although we try our best.
+The _nightly_ builds are snapshots of the codebase at a specific time. They may contain more bugs than usual, although we try our best. Use them for testing the newest features:
 
-=== Build from Source
-You can find the instructions to build from source link:http://ci.kicad-pcb.org/job/kicad-doxygen/ws/Documentation/doxygen/html/md_Documentation_development_compiling.html#build_osx[here]. 
-
-Do not use the https://github.com/KiCad/KicadOSXBuilder[KicadOSXBuilder] as it is outdated. 
+http://downloads.kicad-pcb.org/osx/nightly/

--- a/content/download/source.adoc
+++ b/content/download/source.adoc
@@ -21,7 +21,10 @@ elements that make up the full KiCad package, which is the KiCad
 documentaiton (kicad-doc), the user interface translations
 (kicad-i18n), and the schematic, footprint and 3D model libraries.
 
-=== 4.0.1 Stable Release
+=== Stable Release
+
+Current Version: *4.0.1*
+
 Tarballs intended to be used by packagers:
 
 * link:https://launchpad.net/kicad/4.0/4.0.1/+download/kicad-4.0.1.tar.xz[Source code]
@@ -51,3 +54,5 @@ to enable python scripting].
 Instructions can be found in compiling.md which is located in the kicad source code under /Documentation/development folder.
 
 Alternatively, you can view it online here: link:http://ci.kicad-pcb.org/job/kicad-doxygen/ws/Documentation/doxygen/html/md_Documentation_development_compiling.html[Building KiCad from Source]
+
+Do not use the https://github.com/KiCad/KicadOSXBuilder[KicadOSXBuilder] as it is outdated.

--- a/content/download/windows.adoc
+++ b/content/download/windows.adoc
@@ -4,25 +4,22 @@ iconhtml = "<div><i class='fa fa-windows'></i></div>"
 weight = 2
 +++
 
-=== 4.0.1 Stable Release
+KiCad is supported from Windows XP to Windows 10.
+
+=== Stable Release
 
 Current Version: *4.0.1*
 
-The stable release is available for KiCad 4.0.1 and an installer.
-
-This release version is available at:
-
-link:http://downloads.kicad-pcb.org/windows/stable/kicad-product-4.0.1-x86_64.exe[Windows 64-bit (x86_64)]
-
-link:http://downloads.kicad-pcb.org/windows/stable/kicad-product-4.0.1-i686.exe[Windows 32-bit (i686)]
+- http://downloads.kicad-pcb.org/windows/stable/kicad-product-4.0.1-x86_64.exe[[fa fa-download]#&nbsp;# Windows 64-bit (x86_64)]
+- http://downloads.kicad-pcb.org/windows/stable/kicad-product-4.0.1-i686.exe[[fa fa-download]#&nbsp;# Windows 32-bit (i686)]
 
 === Nightly Development Builds
-Nightly development builds of the latest source for testing can be found here:
 
-http://downloads.kicad-pcb.org/windows/
+The _nightly_ builds are snapshots of the codebase at a specific time. They may contain more bugs than usual, although we try our best. Use them for testing the newest features:
+
+http://downloads.kicad-pcb.org/windows/nightly/
 
 === Old Stable
-The 2013 stable release installer is available at
-http://downloads.kicad-pcb.org/archive/KiCad_stable-2013.07.07-BZR4022_Win_full_version.exe
-It is not recommended for new projects. Please use the new stable release.
 
+The http://downloads.kicad-pcb.org/archive/KiCad_stable-2013.07.07-BZR4022_Win_full_version.exe[2013 old stable release]
+installer is not recommended for new projects. Please use the new stable release.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,8 +17,8 @@
                   <a href="/download/" class="btn btn-default btn-primary">
                     <i class="fa fa-download fa-fw"></i> <span class="network-name">Download</span>
                     <i class="fa fa-linux"></i>
-                    <i class="fa fa-windows"></i>
                     <i class="fa fa-apple"></i>
+                    <i class="fa fa-windows"></i>
                   </a>
                 </li>
               </ul>


### PR DESCRIPTION
- Move the dmg description to the top, they apply to all versions.
- Add icons so that download links stand out.
- Move pertinent build instructions to the dedicated page.
- Actually say that nightly has newer features.
- Append "nightly" to the nightly link.
- On homepage, switch Windows and Apple icons. They are now in the order of the download page.

Preview:
http://www.dallens.fr/download/osx/
Reference:
http://kicad-pcb.org/download/osx/
