### PR TITLE
Point Debian users at backports archive

### DIFF
--- a/content/download/debian.adoc
+++ b/content/download/debian.adoc
@@ -4,21 +4,22 @@ iconhtml = "<div class='fl-debian'></div>"
 weight = 10
 +++
 
-https://packages.debian.org/sid/kicad
+https://packages.debian.org/kicad
 
-=== 4.0.0 Pre-release
+=== Stable Series
 
-A pre-release "release candidate" is available for KiCad 4.0.0.
+If you run Debian *unstable* or *testing*, stable releases of KiCad can be
+installed regularly through apt.
 
-Current Version: *4.0.0 RC1*
-
-This pre-release version is available in debian _sid_ (debian unstable), so you can install it with these commands into a terminal:
+If you run Debian *stable*, you can add the
+link:http://backports.debian.org/[Backports archive] to your sources.list
+if you have not already done so, and install kicad from there.
 
 [source,bash]
 sudo apt-get update
 sudo apt-get install kicad
 
-Offline docs are available in seperate pacakges named for example `kicad-doc-en`.
+Offline docs are available in seperate packages named for example `kicad-doc-en`.
 
 === Old Stable
 The 2013 stable release of KiCad is available in the official Debian repos before sid.


### PR DESCRIPTION
This points users at the Debian backports archive, where a somewhat recent release of KiCad can be found.