### PR TITLE
debian.adoc: adding additional dep package for build from source

### DIFF
--- a/content/download/debian.adoc
+++ b/content/download/debian.adoc
@@ -59,4 +59,4 @@ you have installed some build dependencies at least before:
 [source.bash]
 sudo apt-get install libwxbase3.0-dev libwxgtk3.0-dev libgl1-mesa-dev \
 libglew-dev libglm-dev libcurl4-openssl-dev libboost-dev libboost-thread-dev \
-libboost-system-dev libboost-context-dev libssl-dev wx-common
+libcairo2-dev libboost-system-dev libboost-context-dev libssl-dev wx-common


### PR DESCRIPTION
The current KiCad source need also at least the libcairo-dev package to
get the source successful built.