### PR TITLE
Update the Fedora information

### DIFF
--- a/content/download/fedora.adoc
+++ b/content/download/fedora.adoc
@@ -4,13 +4,22 @@ iconhtml = "<div class='fl-fedora'></div>"
 weight = 20
 +++
 
-=== 4.0.2 Stable Release
-KiCad 4.0.2 is available in the Fedora 23 repo.
+=== Stable Release
+In general, latest Fedora releases ship the stable versions KiCad as they are
+released.
 
-To install KiCad 4.0.2 on Fedora 23 open a terminal and run the following command:
+To install the most recent stable KiCad package on Fedora simply search for it
+in the Software app or open a terminal and run the following command:
 
 [source,bash]
 dnf install kicad
+
+In case the latest KiCad release is not yet available in the updates repository,
+chances are you'll find it in the testing repository. Run the following command
+to install a testing package:
+
+[source,bash]
+dnf --enablerepo=updates-testing install kicad
 
 === Nightly Development Builds
 
@@ -28,16 +37,5 @@ dnf install kicad
 If you don't have copr install with:
 
 ----
-yum install dnf-plugins-core
+dnf install dnf-plugins-core
 ----
-
-As a side note, the wxwidgets build in the copr build is forcing `--with=gtk2` on wxgtk, otherwise eeschema and the legacy canvas does not work properly. 
-This could be problematic if you have other applications depending on wxgtk already. This is a workaround to bring KiCad to fedora more easily.
-
-=== Old Stable
-The 2013 stable release of KiCad is currently available in the official fedora repositories before Fedora 24.
-It is not recommended for new projects. Please use the new stable release.
-If you wish to install old stable search for KiCad in the package manager or run the following command in a terminal:
-
-[source,bash]
-sudo yum install kicad

--- a/content/download/fedora.adoc
+++ b/content/download/fedora.adoc
@@ -24,14 +24,22 @@ dnf --enablerepo=updates-testing install kicad
 === Nightly Development Builds
 
 Nightly development builds for Fedora are available via the
-link:https://copr.fedoraproject.org/coprs/mangelajo/kicad/[copr build
+link:https://copr.fedoraproject.org/coprs/@kicad/kicad/[copr build
 service].
 
 This build can be installed on Fedora with:
 
 ----
-dnf copr enable mangelajo/kicad
+dnf copr enable @kicad/kicad
 dnf install kicad
+----
+
+The `@kicad/kicad` repository replaces the `mangelajo/kicad` repository that was
+previously used to deliver the development builds. If you've previously used it
+you can safely remove it now:
+
+----
+dnf copr remove mangelajo/kicad
 ----
 
 If you don't have copr install with:


### PR DESCRIPTION
The page regularly fails to be up to date with Fedora's update cycle;
let's replace specific versions with a general description of how
KiCad is updated in Fedora, including the reference to testing packages.

Also, bring some details up to date:
* Avoid using "yum" that is superseded by "dnf" for some time already
* Remove the note on wxgtk on gtk2 -- it doesn't conflict with the gtk3
  build anymore.

A side note: keeping the version list up to date is probably as much work as preparing an update of a new KiCad versions for Fedora. If anyone involved in KiCad development is interested in maintaining an up to date version script I invite them to also consider joining the Fedora package collection maintainers and help keep KiCad in Fedora up to date.