### PR TITLE
debian: update information for Debian packages of kicad

### DIFF
--- a/content/download/debian.adoc
+++ b/content/download/debian.adoc
@@ -6,57 +6,80 @@ weight = 10
 
 === Debian Unstable (Sid)
 
-Current Version: *4.0.5* (KiCad actual version)
+Current Version: *4.0.5*
 
-The current upstream release 4.0.5 is available for Debian
-https://packages.debian.org/sid/kicad[unstable/sid].
+Related due the freeze time before the recently published Debian release 9.0
+(Stretch) the current upstream release 4.0.6 isn't available for Debian in
+https://packages.debian.org/sid/kicad[unstable/sid]. The packages for version
+4.0.6 are currently waiting for a review by the FTP-Master team as they
+containing a new binary package for the documentation in Indonesian. Hopefully
+4.0.6 it will be available soon in unstable/sid.
 
-=== Debian Testing (Stretch)
+For installing please read further.
 
-Current Version: *4.0.5* (KiCad actual version)
+=== Debian Testing (Buster)
 
-The current upstream release 4.0.5 is available for Debian
-https://packages.debian.org/stretch/kicad[testing/stretch] and
+Current Version: *4.0.5*
+
+Version 4.0.6 will be available once the packages have automigrated from
+unstable/sid.
+
+=== Debian Stable (Stretch)
+
+Stretch Backports Version: currently none, but planned
+
+Stretch Release Version: *4.0.5*
+
+The release 4.0.5 is available for Debian
+https://packages.debian.org/stretch/kicad[stable/stretch].
 
 You can install it with the following commands in a terminal, otherwise you can
 use the package manager you like:
 
 [source,bash]
-sudo apt-get update
-sudo apt-get install kicad
+sudo apt update
+sudo apt install kicad
 
 Offline docs are available in seperate packages named for example
 `kicad-doc-en`. You can search for them with _apt-cache_ for example
 
 [source.bash]
+apt search kicad-doc
+# or alternatively if you are on wheezy
 apt-cache search kicad-doc
 
-=== Debian Stable (Jessie)
+=== Debian Old-Stable (Jessie)
 
-Jessie-Backport Version: *4.0.5* (KiCad actual version)
+Jessie Backport Version: *4.0.5*
 
 or
 
-Jessie Stable Release Version: *bzr4027* (KiCad stable release 2014)
+Jessie Release Version: *bzr4027* (KiCad stable release 2014)
 
 The 2014 stable release bzr4027 of KiCad is available in the official Debian
-repositories for https://packages.debian.org/jessie/kicad[stable/jessie].
+repositories for https://packages.debian.org/jessie/kicad[oldstable/jessie].
 It is not recommended for new designs. Please use the packages from the
 backport repository for actual versions. Follow the instructions on the
 https://wiki.debian.org/Backports[Debian Wiki] to add the Backport repository
 to your sources and install the KiCad packages from
 https://packages.debian.org/jessie-backports/kicad[jessie-backports].
 
-=== Debian Old-Stable (Wheezy)
+=== Debian Old-Old-Stable (Wheezy)
 
-Current version: *bzr3261* (KiCad stable release 2012), or *bzr4027* via
-Backports
+Wheezy Backport Version: *bzr4027*
 
-Unfortunately there is only release bzr3261 from 2012 in the old-stable
-repository and version bzr4027 (this is the same as on current stable) in the
-old-stable-backport repository. As for Debian stable, it's recommend for new
-designs. So you better upgrade your Debian installation to Debian Stable
-(Jessie) and use the version there from backport.
+or
+
+Wheezy Release Version: *bzr3261* (KiCad stable release 2012)
+
+Unfortunately there is no newer version for the Wheezy release available so you
+need to stay with bzr3261 from 2012 in the old-old-stable repository or version
+bzr4027 from the
+https://packages.debian.org/wheezy-backports/kicad[wheezy-backport] repository
+then. As for Debian old-stable, they are not recommended for new designs. So
+you really better upgrade your Debian installation at least to Debian
+Old-Stable (Jessie) or better to Stable (Stretch) and use the version there
+from backport.
 
 === Build from Source
 You can find the instructions to build from source
@@ -73,8 +96,8 @@ Ensure you have installed some build dependencies at least before you try to
 start own builds:
 
 [source.bash]
-sudo apt-get install doxygen libboost-context-dev libboost-dev \
-libboost-system-dev libboost-thread-dev libcairo2-dev libcurl4-openssl-dev \
+sudo apt install cmake doxygen libboost-context-dev libboost-dev \
+libboost-system-dev libboost-test-dev libcairo2-dev libcurl4-openssl-dev \
 libgl1-mesa-dev libglew-dev libglm-dev liboce-foundation-dev liboce-ocaf-dev \
 libssl-dev libwxbase3.0-dev libwxgtk3.0-dev python-dev python-wxgtk3.0-dev \
 swig wx-common


### PR DESCRIPTION
Update the complete part for Debian.
Debian has released a new stable release so add a new part for this
release called Stretch. Finally also kicad 4.0.5 in jessie-backports
has arrived and all recent releases (Testing, Stretch and Jessie) can
provide the same version of KiCad for now.