### PR TITLE
debian: 4.0.6 has reached unstable and testing

### DIFF
--- a/content/download/debian.adoc
+++ b/content/download/debian.adoc
@@ -6,23 +6,21 @@ weight = 10
 
 === Debian Unstable (Sid)
 
-Current Version: *4.0.5*
+Current Version: *4.0.6* (KiCad actual version)
 
-Related due the freeze time before the recently published Debian release 9.0
-(Stretch) the current upstream release 4.0.6 isn't available for Debian in
-https://packages.debian.org/sid/kicad[unstable/sid]. The packages for version
-4.0.6 are currently waiting for a review by the FTP-Master team as they
-containing a new binary package for the documentation in Indonesian. Hopefully
-4.0.6 it will be available soon in unstable/sid.
+The current upstream release 4.0.6 is available for Debian
+https://packages.debian.org/sid/kicad[unstable/sid].
 
 For installing please read further.
 
 === Debian Testing (Buster)
 
-Current Version: *4.0.5*
+Current Version: *4.0.6* (KiCad actual version)
 
-Version 4.0.6 will be available once the packages have automigrated from
-unstable/sid.
+The current upstream release 4.0.6 is available for Debian
+https://packages.debian.org/testing/kicad[testing/buster].
+
+For installing please read further.
 
 === Debian Stable (Stretch)
 
@@ -34,14 +32,14 @@ The release 4.0.5 is available for Debian
 https://packages.debian.org/stretch/kicad[stable/stretch].
 
 You can install it with the following commands in a terminal, otherwise you can
-use the package manager you like:
+use any of the package managers you like:
 
 [source,bash]
 sudo apt update
 sudo apt install kicad
 
 Offline docs are available in seperate packages named for example
-`kicad-doc-en`. You can search for them with _apt-cache_ for example
+`kicad-doc-en`. You can search for them with _apt_ or _apt-cache_ for example.
 
 [source.bash]
 apt search kicad-doc


### PR DESCRIPTION
The ftpmaster have accepted the current packaging of 4.0.6 and by this
Debian can provide the current upstream stable version in unstable and
testing now.