### PR TITLE
[WIP] Add the GNU Guix package to download

### DIFF
--- a/content/download/gnu-guix.adoc
+++ b/content/download/gnu-guix.adoc
@@ -1,0 +1,13 @@
++++
+title = "GNU Guix"
+iconhtml = "<div class='fl-gnuguix'></div>"
+weight = 95
++++
+
+=== Stable Release
+The stable release of KiCad is available as
+link:https://www.gnu.org/software/guix/packages/k.html[package in guix].
+ You can install it with:
+
+  guix package -i kicad
+

--- a/static/fonts/font-linux.css
+++ b/static/fonts/font-linux.css
@@ -56,6 +56,7 @@
 .fl-fedora:before,
 .fl-freebsd:before,
 .fl-gentoo:before,
+.fl-gnuguix:before,
 .fl-linuxmint:before,
 .fl-linuxmint-inverse:before,
 .fl-mageia:before,
@@ -88,6 +89,7 @@
 .fl-fedora:before { content: "\f103"; }
 .fl-freebsd:before { content: "\f10f"; }
 .fl-gentoo:before { content: "\f111"; }
+.fl-gnuguix:before { content: "\f113"; }
 .fl-linuxmint:before { content: "\f105"; }
 .fl-linuxmint-inverse:before { content: "\f106"; }
 .fl-mageia:before { content: "\f107"; }


### PR DESCRIPTION
Kicad is available in [GNU Guix](https://www.gnu.org/software/guix/) package manager. So this PR tries to add this info to the Download site of Kicad. Sadly I didn't manage to add an SVG-Logo of Guix to the font-linux.svg file via fontforge and inkscape.

The svg-file is [here](https://jons.gr/Guix_bw.svg). It would be nice if someone could help me out on this task :) Or just give me the right hint how to do that...

Cheers Jonathan