### PR TITLE
Additions and reformatting to 5.0.0 release draft

### DIFF
--- a/content/post/release-5.0.0.adoc
+++ b/content/post/release-5.0.0.adoc
@@ -4,32 +4,47 @@ date = "2017-11-29"
 draft = true
 +++
 [Kicad-developers] [Feature] Position Relative to
-[Kicad-developers] [PATCH] GerbView GAL support
 [Kicad-developers] [FEATURE] Eeschema Line Styles
 [Kicad-developers] [RFC] new connectivity algorithm - testers needed
 
 
-New features in KiCad 5.0.0
+== New features in KiCad 5.0.0
 
-- Autoplace for eeschema labels (https://www.youtube.com/watch?v=32FKnrKxe4Y)
-- New 3D viewer
-- New 3D model plugin archetecture
- -- Now supports STEP and IGES viewer
- -- STEP assembly export from STEP and IGES inputs
- -- Otherwise support for VRML as before
-- Flip board option
-- Spread out when loading netlist with new parts in pcbnew
-- SPICE via ngspice
-- New component chooser in eescheme, see email  [Kicad-developers] Pushed new component selector
-- Selection of nets on a sheet [Kicad-developers] Selection tool that selects components and local connections
-- Many tool fixes to GAL
-  - Grid option works
-  - Caliper tool in GAL
-- [Kicad-developers] [PATCH] [RFC] Get rid of boost::context
-- [Kicad-developers] [FEATURE] Component table viewer
+=== Project-wide
 
+* New 3D viewer
+* New 3D model plugin archetecture
+** Now supports STEP and IGES viewer
+** STEP assembly export from STEP and IGES inputs
+** Otherwise support for VRML as before
+* Many tool fixes to GAL
+** Grid option works
+** Caliper tool in GAL
+* Support for arbitrary color schemes (GerbView and PcbNew: in OpenGL/Cairo canvases only)
+* New highlighting style for disambiguating selections for greater clarity
+* Improved zoom behavior when using trackpads in MacOS
+* [Kicad-developers] [PATCH] [RFC] Get rid of boost::context
+* [Kicad-developers] [FEATURE] Component table viewer
 
-possible new features, needs to be verified
-- custom rastnet highlighting
+=== Eeschema
+
+* Autoplace for eeschema labels (https://www.youtube.com/watch?v=32FKnrKxe4Y)
+* SPICE simulation support via ngspice
+* New component chooser, see email  [Kicad-developers] Pushed new component selector
+* Selection of nets on a sheet [Kicad-developers] Selection tool that selects components and local connections
+
+=== PcbNew
+
+* Flip board option
+* Spread out when loading netlist with new parts
+
+=== GerbView
+
+* Support for new GAL (OpenGL and Cairo) canvases
+* New measurement tool
+* Ability to pan using a drag of the right mouse button
+
+=== Possible new features, needs to be verified
+* custom rastnet highlighting
 
 


### PR DESCRIPTION
bullets changed from `-` to `*` so that the multi-level bullets render properly in the Github preview