### PR TITLE
[KLC update] Tantalum caps: move letter code towards the back

### DIFF
--- a/content/libraries/klc.adoc
+++ b/content/libraries/klc.adoc
@@ -13,7 +13,7 @@ aliases = [ "/klc/" ]
 toc::[]
 
 
-**link:/libraries/klc/history/[Revision: 3.0.3]**
+**link:/libraries/klc/history/[Revision: 3.0.4]**
 
 ---
 

--- a/content/libraries/klc_history.adoc
+++ b/content/libraries/klc_history.adoc
@@ -6,6 +6,10 @@ url = "/libraries/klc/history/"
 
 ---
 
+== 3.0.4 - 2017-11-30
+* Fix naming convention for tantal caps
+** move size code towards the back to avoid impression that these are manufacturer specific
+
 == 3.0.3 - 2017-11-14
 * Allow pin name offset values less than 20mils (`must` -> `should`)
 

--- a/data/fpnaming/cap_tant_smd.yaml
+++ b/data/fpnaming/cap_tant_smd.yaml
@@ -3,21 +3,17 @@ name: cap_tant_smd
 entries:
     - code: "CP_Tantalum"
       example: "CP_Tantalum"
-    - code: Manufacturer
-      title: Manufacturer name
-      optional: 1
-      example: Kemet
-    - code: Size code
-      example: A
-      title: Manufacturer size code
     - code: Metric size
       prefix: "EIA-"
       example: "3126-18"
       title: EIA metric size code
+    - code: Size code
+      example: Kemet-A
+      title: Letter size code including naming standard ([Standard]-[Letter])
     - code: Modifiers
       title: Footprint modifiers if non standard
       optional: 1
     - code: Options
       title: Footprint options
       optional: 1
-      example: Reflow
+      example: Pad1.53x1.40mm_HandSolder


### PR DESCRIPTION
This is to avoid the impression that tantulum capacitor footprints
are manufacturer specific.

We noticed the confusion in reported issue: https://github.com/KiCad/kicad-packages3D/issues/176
The renaming happened in this merged pull request: https://github.com/KiCad/kicad-footprints/pull/136
