### PR TITLE
[KLC] Fixed the examples in rule 3.6 (connector naming)

### DIFF
--- a/content/klc/F3.6.adoc
+++ b/content/klc/F3.6.adoc
@@ -48,9 +48,9 @@ Many connectors are designed for specific functions (e.g. USB, HDMI, SD-Card, et
 Notes:
 
 . Some _examples_ of functional connector naming are provided below:
-* `USB_Micro-B_Wuerth-614105150721_Vertical_CircularHoles`
+* `USB_Micro-B_Wuerth_614105150721_Vertical_CircularHoles`
 * `HDMI_Micro-D_Molex_46765-2x0x`
-* `MicroSD_Wurth_693072010801`
+* `MicroSD_Wurth_WR-CRD_693072010801`
 . In most cases, pin layout does not need to be explicitly specified
 
 === Connectors with Standardised Shape

--- a/content/klc/F3.6.adoc
+++ b/content/klc/F3.6.adoc
@@ -50,7 +50,7 @@ Notes:
 . Some _examples_ of functional connector naming are provided below:
 * `USB_Micro-B_Wuerth_614105150721_Vertical_CircularHoles`
 * `HDMI_Micro-D_Molex_46765-2x0x`
-* `MicroSD_Wurth_WR-CRD_693072010801`
+* `MicroSD_Wuerth_WR-CRD_693072010801`
 . In most cases, pin layout does not need to be explicitly specified
 
 === Connectors with Standardised Shape

--- a/content/libraries/klc.adoc
+++ b/content/libraries/klc.adoc
@@ -13,7 +13,7 @@ aliases = [ "/klc/" ]
 toc::[]
 
 
-**link:/libraries/klc/history/[Revision: 3.0.4]**
+**link:/libraries/klc/history/[Revision: 3.0.5]**
 
 ---
 

--- a/content/libraries/klc_history.adoc
+++ b/content/libraries/klc_history.adoc
@@ -6,6 +6,9 @@ url = "/libraries/klc/history/"
 
 ---
 
+== 3.0.5 - 2017-12-05
+* Fix examples in connector naming convention
+
 == 3.0.4 - 2017-11-30
 * Fix naming convention for tantal caps
 ** move size code towards the back to avoid impression that these are manufacturer specific


### PR DESCRIPTION
This pull request does fix some errors in the examples in the connector naming convention.
We discovered the problem in the discussion for pull request https://github.com/KiCad/kicad-footprints/pull/153