### PR TITLE
KLC: specify paste coverage range for exposed pads.

### DIFF
--- a/content/klc/F6.3.adoc
+++ b/content/klc/F6.3.adoc
@@ -27,6 +27,7 @@ Custom stencil openings are accommodated as follows:
 [loweralpha]
 . Construct copper shape with pad(s) with only copper layers (`F.Cu` and/or `B.Cu`) as appropriate. These copper pads should not have the `F.Paste` or `B.Paste` layers checked.
 . Add stencil opening(s) with pad(s) which only use solderpaste layers (`F.Paste` and/or `B.Paste`) as required. These pads _do not have a pad number_.
+. The solderpaste should cover between 50% and 80% of the soldermask free pad area.
 
 *Result:* _(note: this footprint does not correspond to the example shown above)_
 

--- a/content/libraries/klc.adoc
+++ b/content/libraries/klc.adoc
@@ -13,7 +13,7 @@ aliases = [ "/klc/" ]
 toc::[]
 
 
-**link:/libraries/klc/history/[Revision: 3.0.8]**
+**link:/libraries/klc/history/[Revision: 3.0.9]**
 
 ---
 

--- a/content/libraries/klc_history.adoc
+++ b/content/libraries/klc_history.adoc
@@ -6,6 +6,9 @@ url = "/libraries/klc/history/"
 
 ---
 
+== 3.0.9 - 2017-01-19
+* Specify solderpaste coverage for exposed pads
+
 == 3.0.8 - 2017-01-02
 * extended S5.2 to explain pin-count in FPFilters
 


### PR DESCRIPTION
Discussion in https://github.com/KiCad/kicad-footprints/issues/211.