### PR TITLE
Make it more clear what library is intended for what kicad release

### DIFF
--- a/content/libraries/download.adoc
+++ b/content/libraries/download.adoc
@@ -8,7 +8,14 @@ title = "Download Libraries"
     weight = 10
 +++
 
-== Library Downloads
+== Library Downloads for KiCad Version 4
+Snapshots of the libraries aligned with the minor KiCad 4 releases link:http://downloads.kicad-pcb.org/libraries/[can be found here].
+
+
+KiCad 4.0.x releases come with local symbol and 3d model libraries included. The footprint libraries are special cases in most installation. They are setup to use on demand download from github (via the github plugin). This might not be right for every user. For these users it is advisable to download a library snapshot and add these libs to kicad via the footprint library manager found in the preferences menu of pcb_new and the footprint editor. For the best results it is recommended to ensure KiCad does use all types of libraries from the same snapshot.
+
+
+== Library Downloads for the Future KiCad Version 5
 
 The official KiCad libraries are available for download at link:https://kicad.github.io[https://kicad.github.io]. Library data are provided as compressed archives of the individual libraries within the following categories:
 
@@ -24,7 +31,7 @@ At the moment, libraries are included along with KiCad installation. You will on
 
 KiCad libraries are community contributed and hosted on GitHub at link:https://github.com/kicad[github.com/kicad]. If you wish to contribute to the libraries, refer to the link:/libraries/contribute/[contribution guide].
 
-=== Library Repositories
+=== Library Repositories for KiCad Version 4
 
 The set of libraries corresponding to `v4.xx` of KiCad software are organised on GitHub as follows:
 
@@ -32,9 +39,9 @@ The set of libraries corresponding to `v4.xx` of KiCad software are organised on
 
 **Footprint** libraries are stored as link:https://github.com/kicad?&q=.pretty[individual repositories] with the `.pretty` extension.
 
-=== Future of the Libraries
+=== Library Repositories for the Future KiCad Version 5
 
-In conjunction with the KiCad v5 software release, the libraries will be reorganised into four separate repositories (on GitHub). These repositories are currently a work in progress.
+In conjunction with the KiCad v5 software release, the libraries will be reorganised into four separate repositories (on GitHub). **These repositories are currently a work in progress.**
 
 * `link:https://github.com/KiCad/kicad-symbols[kicad-symbols]` - Schematic symbol libraries
 * `link:https://github.com/KiCad/kicad-footprints[kicad-footprints]` - PCB footprint libraries


### PR DESCRIPTION
As we got a few complaints from users of the stable release that the new libs to not work for them i decided to make it more clear on the download page that the new repos are intended for KiCad version 5.

I also added a requirement section on the github.io download pages, added this information to the readme files and gave the repos them selves a description that mentions kicad 5 as well. I hope this will be enough to guide users to the correct version of the library.

Edit: We will try to provide a backport release of the new library that will be compatible with kicad 4. But as this is extra work we do not want to do this too early. (We want to finish the transfer from the old library first.)