### PR TITLE
[KLC] Concept clarification: generic, fully specified and atomic

### DIFF
--- a/content/klc/G2.1.adoc
+++ b/content/klc/G2.1.adoc
@@ -1,21 +1,47 @@
 +++
-brief = "Defining generic and atomic parts"
+brief = "Generic, fully specified and atomic parts."
 +++
 
-In general terms, the _symbols_ in the KiCad library can be categorized into two groups:
+KiCad is flexible with how symbols and footprints can be connected. In general there are at least two workflows:
+. Generic symbol: Assign the footprint after (or during) symbol placement in eeschema.
+.. Footprint filters may be used to reduce the set of possible footprints.
+. Fully specified symbol: Assign a default footprint in the symbol.
+.. Footprint field is set for one footprint
+.. Footprint filters allow selection of slight variations of this footprint
+
+The later workflow can be split up further
+. Symbol represents a family of parts produced by many manufacturers
+.. Symbol name is the base part number plus a suffix for communicating the connected footprint
+. Symbol represents one part but does use a generic footprint
+.. Symbol name is the full manufacturer part number
+. Both symbol and footprint are specific to one part (= atomic part)
+.. Both symbol and footprint name contain the manufacturer part number
+
+Details about symbol naming can be found in link:/libraries/klc/#s2/[KLC 2.x]
 
 **Generic symbols**
 
 Generic symbols can be used with multiple footprints, and _do not_ have a default footprint assigned. Generic symbols allow flexibility in the design workflow. Symbols are first added to the schematic, and the footprint is selected before PCB layout. Using generic symbols allows a small number of library symbol elements to represent a _very large number_ of possible component combinations.
 
-An example of the use of generic symbols is the **Resistor** and **Capacitor** symbols available in the KiCad library. These symbols do not have an assigned default footprint, as there are _many_ possible compatible footprints.
+Generic symbols are limited to the following libraries:
+. Device
+. Connector and all Connector_Generic derivatives
+. Switch
+. And to some extend the Logic libs.
+
+An example of the use of generic symbols are the **Resistor** and **Capacitor** symbols available in the KiCad library. These symbols do not have an assigned default footprint, as there are _many_ possible compatible footprints.
 
 {{< klcimg src="G2.1a" title="Single schematic symbol" >}} {{< klcimg src="G2.1b" title="Associated with multiple footprints" >}}
 
-**Atomic Parts**
+**Fully specified symbols or atomic parts**
 
-Atomic parts fully define a component, specifying a matching footprint, and are named based on the `MPN` (manufacturer part number). Atomic parts are ready to be placed onto the PCB as they are already associated with a footprint.
+These fully define a component, specifying a matching footprint, and are named based on the `MPN` (manufacturer part number). They are ready to be placed onto the PCB as they are already associated with a footprint.
 
 {{< klcimg src="G2.1c" title="Atomic symbol" >}}
 
+**Preference in the library**
 
+The preferred option are fully specified symbols with symbol name equal to the manufacturer part number and a generic footprint assigned to it.
+Where a part is produced in a compatible form by many manufactuers it is allowed to create a more generic variation with the footprint indicated via a suffix.
+Atomic parts rarely make sense for the official library. It is allowed to be used where a component has a footprint that is highly specialized to this component. (Example are some relays)
+Generic symbols should only be used where it does not make sense to have a specialized symbol for every possible variation.

--- a/content/klc/S2.1.adoc
+++ b/content/klc/S2.1.adoc
@@ -2,12 +2,16 @@
 brief = "General symbol naming guidelines"
 +++
 
-. Library naming should not be duplicated in footprint name
-. If symbol with same name exists for multiple manufacturers, the manufacturer name is written first
-. Specific manufacturer name (for atomic parts)
-. Type of symbol (for generic parts)
+. Library naming should not be duplicated in symbol name
+. Symbol representing one specific component
+.. The manufacturer part number is used as the symbol name (More detail see link:/libraries/klc/S2.2/[KLC 2.2])
+.. If a symbol with the same name exists for multiple manufacturers, the manufacturer name is written first
+. Symbol representing a compatible part produced by multiple manufacturers:
+.. Symbol name is the base part number. (The element of the part number shared by all manufacturers.)
+.. A suffix indicating the connected footprint is added
+.. Examples: `L78L05_SO8`, `LM358_DFN8`
+. Name for generic symbols
 .. May be shortened for common components (e.g. `Conn` for `Connector`)
 .. Reference designator may be substituted for common components (e.g. `D`, `C`, `LED`)
-. Part name should include extension for specific footprint if required (e.g. `SOIC`)
-. Any modification of the original symbol, indicated by appending the reason (e.g. different pin ordering - `Q_NPN_CBE`, `Q_NPN_BCE`)
-. Indicate quantity of elements for symbol arrays (e.g. resistor array with 8 elements - `Resistor_x8`)
+.. Any modification of the original symbol, indicated by appending the reason (e.g. different pin ordering - `Q_NPN_CBE`, `Q_NPN_BCE`)
+.. Indicate quantity of elements for symbol arrays (e.g. resistor array with 8 elements - `Resistor_x8`)

--- a/content/klc/S2.2.adoc
+++ b/content/klc/S2.2.adoc
@@ -10,10 +10,10 @@ Examples:
 * Packaging information (e.g. reel, tray, tape)
 * RoHS / PbFree information
 
-To capture every possible combination of part variation requires a large number of symbol aliases - this is to be avoided.
+To capture every possible combination of part variation would require a large number of symbol aliases - this is to be avoided.
 
-Where an MPN has options for such non-functional variations, these portions of the MPN should be replaced with a wildcard character (`x`).
+Where a MPN has options for such non-functional variations, these portions of the MPN should be replaced with a wildcard character (`x`).
 
 **Rule of thumb**
 
-A single symbol should be drawn for each footprint variation of an atomic part. Other variations (as listed above) do not require their own symbol alias.
+A single symbol should be drawn for each footprint variation of a fully specified symbol (or atomic part). Other variations (as listed above) do not require their own symbol but should be added as an alias.

--- a/content/libraries/klc.adoc
+++ b/content/libraries/klc.adoc
@@ -34,7 +34,7 @@ The general library guidelines apply to all library elements (symbols / footprin
 
 {{< klc_list title="General Guidelines" filter="G1.">}}
 
-{{< klc_list title="Atomic and Generic Parts" filter="G2." >}}
+{{< klc_list title="Symbol - Footprint Connection Styles" filter="G2." >}}
 
 ---
 == Symbol Guidelines

--- a/content/libraries/klc_history.adoc
+++ b/content/libraries/klc_history.adoc
@@ -6,6 +6,9 @@ url = "/libraries/klc/history/"
 
 ---
 
+== 3.0.12 - 2018-02-15
+* Clarification of symbol to footprint connection scheme. (Generic, fully specified, atomic)
+
 == 3.0.11 - 2018-01-25
 * Remove mentions of ThermalPad(s) suffix from all rules. (The only thermals related suffix is ThermalVias)
 


### PR DESCRIPTION
Introduction of the therms
- generic symbol
- fully specified symbol (for one specific part or a family of parts)
- atomic parts.

Add more details about symbol naming convention.

---

This is inspired by the discussion in https://github.com/KiCad/kicad-symbols/issues/237
**I did not yet test it in hugo (I am on the wrong PC right now.)**

@evanshultz @jkriege2 @bobc i think this would make everything a bit more clear.