### PR TITLE
Allow rounded rectangle pads for marking pin 1

### DIFF
--- a/content/klc/F7.3.adoc
+++ b/content/klc/F7.3.adoc
@@ -1,8 +1,10 @@
 +++
-brief = "Pin 1 should be rectangular, and other pads circular or oval"
+brief = "Pin 1 should be rectangular or a rounded rectangle. Other pads circular or oval"
 +++
 
-Through hole components should set the shape of Pin 1 to `Rectangular`, and all other pads to either `Circular` or `Oval`. This aids in orienting the component during placement and also for locating Pin 1 for circuit troubleshooting.
+Through hole components should set the shape of Pin 1 to `Rectangular` or `Rounded Rectangle`, and all other pads to either `Circular` or `Oval`.
+This aids in orienting the component during placement and also for locating Pin 1 for circuit troubleshooting.
+For rounded rectangle pads the corner size should be 25% with a maximum radius of 0.25mm.
 
 Pad shape can be adjusted in the *Pad Properties* dialog:
 

--- a/content/libraries/klc.adoc
+++ b/content/libraries/klc.adoc
@@ -13,7 +13,7 @@ aliases = [ "/klc/" ]
 toc::[]
 
 
-**link:/libraries/klc/history/[Revision: 3.0.11]**
+**link:/libraries/klc/history/[Revision: 3.0.12]**
 
 ---
 

--- a/content/libraries/klc_history.adoc
+++ b/content/libraries/klc_history.adoc
@@ -6,6 +6,9 @@ url = "/libraries/klc/history/"
 
 ---
 
+== 3.0.12 - 2018-08-17
+* Allow the use of rounded rectangle pads for marking pin 1 in THT parts.
+
 == 3.0.11 - 2018-01-25
 * Remove mentions of ThermalPad(s) suffix from all rules. (The only thermals related suffix is ThermalVias)
 


### PR DESCRIPTION
Industry standards now suggest the use of rounded rectangle pads. For
this reason it is now allowed to use rounded rectangles in addition to
rectangle pads for marking pin 1 in polarized through hole components.