### PR TITLE
Clarify footprint naming and pin numbers for special pins

### DIFF
--- a/content/klc/F2.1.adoc
+++ b/content/klc/F2.1.adoc
@@ -11,6 +11,15 @@ Each footprint is a `.kicad_mod` file (stored within a `.pretty` directory). The
   * `TO-90`
   * `QFN-48`
   * `DIP-20`
+. Packages with special pads add an identifier to the pin count field separated by a hyphen
+  * The field includes the count of uniquely numberd pads of this type.
+  ** For exposed pads (large copper pad below the part) `[count]EP`
+  ** For shield pads `[count]SH` (Unless such a pin is already expected for the part. An example would be a HDMI connector.)
+  ** For pads connecting pure mechanical mounting leads `[count]MP`
+  * Examples from the library.
+  ** `DFN-6-1EP_2x2mm_P0.5mm_EP0.61x1.42mm`
+  ** `Samtec_LSHM-110-xx.x-x-DV-S_2x10-1SH_P0.50mm_Vertical`
+  ** `Molex_PicoBlade_53261-0271_1x02-1MP_P1.25mm_Horizontal`
 . Unique _fields_ (parameters) in the footprint name are separated by `_` character.
 . Package dimensions are specified as `length` x `width` (and optionally `height`)
   * `3.5x3.5x0.2mm`

--- a/content/klc/S3.7.adoc
+++ b/content/klc/S3.7.adoc
@@ -1,7 +1,17 @@
 +++
-brief = "Pin numbering for exposed pads"
+brief = "Pin numbering for specialized pads"
 +++
 
 For IC components with exposed pads, the number of the exposed pad should start one greater than the pin-count of the footprint.
 
 For a SOIC-8 package with a single exposed pad, the exposed pad will be assigned the number `9`
+
+---
+
+Shielded components use "SH" as the pin number for connecting the shield.
+For a pin to qualify as the shield pin it must be connected to a metal enclosure.
+For connectors it must connect to the shield of the cable.
+
+Parts that include mechanical mounting pads without electrical use, get the pin number "MP".
+Non plated through holes do not get any pad number assigned. (They do not get a pin in the symbol.)
+An example for such a pure mechanical mounting pad would be the pads for the two metal leads on the side of Molex picoblade smd connectors.

--- a/content/libraries/klc.adoc
+++ b/content/libraries/klc.adoc
@@ -13,7 +13,7 @@ aliases = [ "/klc/" ]
 toc::[]
 
 
-**link:/libraries/klc/history/[Revision: 3.0.12]**
+**link:/libraries/klc/history/[Revision: 3.0.13]**
 
 ---
 

--- a/content/libraries/klc_history.adoc
+++ b/content/libraries/klc_history.adoc
@@ -6,6 +6,9 @@ url = "/libraries/klc/history/"
 
 ---
 
+== 3.0.13 - 2018-08-17
+* Clarify footprint naming and pin numbers for parts with shield or mounting pins.
+
 == 3.0.12 - 2018-08-17
 * Allow the use of rounded rectangle pads for marking pin 1 in THT parts.
 

--- a/layouts/shortcodes/fp_prefix.html
+++ b/layouts/shortcodes/fp_prefix.html
@@ -13,14 +13,6 @@
   </td></ul>
 </tr>
 <tr>
-  <td>EP</td><td>Exposed pad</td>
-  <td><ul>
-    <li>Only used if there is one more more exposed pads under a component</li>
-    <li>If there is more than one exposed pad, prepend with the pad count (e.g. <code>3EP</code>)</li>
-    <li>If exposed pad dimensions need to be added, append them here e.g. <code>EP2.4x3.6</code> - 2.4mm x 3.6mm</li>
-  </ul></td>
-</tr>
-<tr>
 <td>D</td><td>Diameter</td>
 <td><ul>
   <li>Diameter of major axis for cylindrical component</li>
@@ -42,13 +34,6 @@
   <li>Body size <code>B</code> should be used in preference, where possible</li>
   <li>e.g. <code>L15.3mm</code> - 15mm length</li>
 </ul></td>
-  </tr>
-<tr>
-  <td>P</td><td>Pad pitch</td>
-  <td><ul>
-    <li>Pitch (distance) between pins, pads or leads</li>
-    <li>e.g. <code>P0.63mm</code> - 0.63mm pitch between pads</li>
-  </ul></td>
 </tr>
 <tr>
   <td>W</td><td>Width</td>
@@ -56,6 +41,19 @@
     <li>Width along minor axis of component</li>
     <li>Body size <code>B</code> should be used in preference, where possible</li>
     <li>e.g. <code>W4.75mm</code> - 4.75mm width</li>
+  </ul></td>
+</tr>
+<tr>
+  <td>EP</td><td>Exposed pad dimensions</td>
+  <td><ul>
+    <li>Packages that include a single exposed pad include the size of this pad. e.g. <code>EP2.4x3.6</code> - for a single 2.4mm x 3.6mm pad.</li>
+  </ul></td>
+</tr>
+<tr>
+  <td>P</td><td>Pad pitch</td>
+  <td><ul>
+    <li>Pitch (distance) between pins, pads or leads</li>
+    <li>e.g. <code>P0.63mm</code> - 0.63mm pitch between pads</li>
   </ul></td>
 </tr>
 <tr>


### PR DESCRIPTION
Parts that include an exposed pad, a mounting pad or a shield pad are
now better defined.

The rules written down in this change are already used in the library.