### PR TITLE
Make back link go to blog page iof folder index

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -13,7 +13,7 @@
       <article>
         {{ .Content }}
         <p>
-          <a href="/post/"><span class="fa fa-arrow-left"></span> Back</a>
+          <a href="/blog/"><span class="fa fa-arrow-left"></span> Back</a>
         </p>
       </article>
     </div>


### PR DESCRIPTION
The back link in blog post goes to http://kicad-pcb.org/post/. This is an index of all blog posts without a proper layout. The list of blog posts with the correct layout is at http://kicad-pcb.org/blog/.