### PR TITLE
KLC S4.7: active low clarifications

### DIFF
--- a/content/klc/S4.7.adoc
+++ b/content/klc/S4.7.adoc
@@ -6,4 +6,8 @@ Rather than selecting the _active low_ graphical pin style, active low pins shou
 
 This provides a cleaner look for the schematic.
 
-To place a line above the pin text, prefix the name with the tilde (`~`) character.
+To place a line above the pin text, prefix the name with the tilde (`~`) character. In case of a pin name where only part of it is
+active low, and hence, not all of it needs a bar above, two tilde characters must be used as delimitation, e.g. `\~SPD_LED~/GPIO2`.
+
+If the pin name given by the manufacturer includes an active low prefix or suffix, it should be removed when adding the bar above it
+to avoid negating it twice. For example for `nRESET`, use `~RESET`.

--- a/content/libraries/klc.adoc
+++ b/content/libraries/klc.adoc
@@ -13,7 +13,7 @@ aliases = [ "/klc/" ]
 toc::[]
 
 
-**link:/libraries/klc/history/[Revision: 3.0.13]**
+**link:/libraries/klc/history/[Revision: 3.0.14]**
 
 ---
 

--- a/content/libraries/klc_history.adoc
+++ b/content/libraries/klc_history.adoc
@@ -5,6 +5,8 @@ url = "/libraries/klc/history/"
 +++
 
 ---
+== 3.0.14 - 2018-09-16
+* Clarify active low pins in symbols (S4.7).
 
 == 3.0.13 - 2018-08-17
 * Clarify footprint naming and pin numbers for parts with shield or mounting pins.


### PR DESCRIPTION
- Active low prefixes/suffixes as discussed on https://github.com/KiCad/kicad-symbols/pull/651
- Clarification added for pin names where not the full name needs a bar above

Thanks!