### PR TITLE
Add STEP files to File Formats page

### DIFF
--- a/content/help/file-formats.adoc
+++ b/content/help/file-formats.adoc
@@ -72,6 +72,8 @@ link:http://bazaar.launchpad.net/~stambaughw/kicad/doc-read-only/download/head:/
 
 * `.wrl`: VRML 3D model used in the 3D viewer to represent parts.
 
+* `.step`: STEP 3D model used for integration with MCAD software packages. KiCad supports STEP file integration and can export board and component models into an integrated STEP file.
+
 KiCad uses a few temporary file formats internally. The files it creates with these extensions (marked above with "^*^" ) can be excluded from version control software since they can be automatically regenerated from the source files when necessary.
 
 == Dedicated file formats

--- a/content/help/file-formats.adoc
+++ b/content/help/file-formats.adoc
@@ -72,7 +72,7 @@ link:http://bazaar.launchpad.net/~stambaughw/kicad/doc-read-only/download/head:/
 
 * `.wrl`: VRML 3D model used in the 3D viewer to represent parts.
 
-* `.step`: STEP 3D model used for integration with MCAD software packages. KiCad supports STEP file integration and can export board and component models into an integrated STEP file.
+* `.step` or `.stp`: STEP 3D model used for integration with MCAD software packages. KiCad supports STEP file integration and can export board and component models into an integrated STEP file.
 
 KiCad uses a few temporary file formats internally. The files it creates with these extensions (marked above with "^*^" ) can be excluded from version control software since they can be automatically regenerated from the source files when necessary.
 


### PR DESCRIPTION
STEP files are now natively supported by KiCad 5 and are commonly used in KiCad 4 projects using the KiCad Step-Up tools. Their existence should be documented on [the File Formats page](http://kicad-pcb.org/help/file-formats/).