### PR TITLE
Add Fedora 29 to the download section of the web site.

### DIFF
--- a/content/download/fedora.adoc
+++ b/content/download/fedora.adoc
@@ -10,6 +10,8 @@ weight = 20
 
 {{< repology fedora_rawhide >}}
 
+{{< repology fedora_29 >}}
+
 {{< repology fedora_28 >}}
 
 {{< repology fedora_27 >}}


### PR DESCRIPTION
This commit adds Fedora 29 to the download section of the web site.