### PR TITLE
KLC F5.1,2,3: Clarify rules for parts with tolerances

### DIFF
--- a/content/klc/F5.2.adoc
+++ b/content/klc/F5.2.adoc
@@ -14,6 +14,7 @@ The following elements must be provided on the fabrication layer(s)
 . Simplified component outline must be provided on `F.Fab` layer
 .. Outline uses line width between {`0.10mm` and `0.15mm`} (recommended `0.10mm`)
 .. Outline should be simplified and not display complex features
+.. For outlines based on the component body shape, the nominal size is used
 . Footprint polarisation / location of pin-1 is drawn
 .. For IC packages, bevel is drawn at corner next to pin-1
 .. Bevel should be `1mm` or `25% of package size` (whichever is smaller)

--- a/content/klc/F5.3.adoc
+++ b/content/klc/F5.3.adoc
@@ -19,10 +19,12 @@ A fully enclosed Component courtyard must be drawn on the `F.CrtYd` layer, with 
 . Courtyard uses `0.05mm` line width
 . All courtyard line elements are placed on a `0.01mm` grid
 . If the component requires a courtyard on the back of the PCB, a corresponding courtyard must be provided on the `B.CrtYd` layer.
+. Where the courtyard depends on the dimensions of the physical part body,
+  clearance is calculated from the nominal part dimensions.
 
 Courtyard clearance should adhere to the following requirements:
 
-[start=4]
+[start=5]
 . Unless otherwise specified, clearance is `0.25mm`
 . Components smaller than `0603` should have a clearance of `0.15mm`
 . Connectors should have a clearance of `0.5mm`, in addition to the clearance required for mating of connector

--- a/content/libraries/klc.adoc
+++ b/content/libraries/klc.adoc
@@ -13,7 +13,7 @@ aliases = [ "/klc/" ]
 toc::[]
 
 
-**link:/libraries/klc/history/[Revision: 3.0.23]**
+**link:/libraries/klc/history/[Revision: 3.0.24]**
 
 ---
 

--- a/content/libraries/klc_history.adoc
+++ b/content/libraries/klc_history.adoc
@@ -5,6 +5,13 @@ url = "/libraries/klc/history/"
 +++
 
 ---
+== 3.0.24 - 2019-11-16
+* Clarify rule for parts with toleranced dimensions
+  * Fab comes from the nominal component dimensions (F5.2)
+  * Courtyards, where based on component sizes (as opposed to where the
+    courtyard comes from the pads), are referenced to the nominal body size.
+    This is an IPC rule. (F5.3)
+
 == 3.0.23 - 2019-09-23
 * Clarify that the silk below tht exception is only for additional silk markings
 * Clearer screenshots for polarized and non polarized silk markings


### PR DESCRIPTION
* Fab comes from the nominal size of the component
* Silk outlines should be such that they allow for the part
  tolerances, so a worst-case, but in-spec, part cannot
  overlap silk that is supposed to be visible after assembly.
* Courtyards allow for part tolerances so that worst-case, but
  in-spec, parts cannot violate the clearances.
----

The idea here is to ensure that a part that is within the promised tolerances (either from a standard like a JEDEC or from the datasheet) will never violate the courtyard (most critical) or cover silkscreen that should be visible (annoying for THT, bad for SMD)

The Fab rule is mostly to guide the user on the right dimensions to use when presented with a min/nominal/max dimensioning system.

This will probably mean that some existing footprints don't meet requirements if the silk or courtyard is based only on nominal sizes.

C.f. Some discussion about a specific part at kicad-footprints: https://github.com/KiCad/kicad-footprints/issues/1095