### PR TITLE
Fedora 27 has reached end-of-life status

### DIFF
--- a/content/download/fedora.adoc
+++ b/content/download/fedora.adoc
@@ -14,8 +14,6 @@ weight = 20
 
 {{< repology fedora_28 >}}
 
-{{< repology fedora_27 >}}
-
 In general, latest Fedora releases ship the stable versions of KiCad as they are
 released.
 


### PR DESCRIPTION
Remove Fedora 27 from the download page.