### PR TITLE
Update Fedora EOL dates

### DIFF
--- a/content/download/fedora.adoc
+++ b/content/download/fedora.adoc
@@ -10,9 +10,9 @@ weight = 20
 
 {{< repology fedora_rawhide >}}
 
-{{< repology fedora_29 >}}
+{{< repology fedora_30 >}}
 
-{{< repology fedora_28 >}}
+{{< repology fedora_29 >}}
 
 In general, latest Fedora releases ship the stable versions of KiCad as they are
 released.

--- a/content/help/system-requirements.adoc
+++ b/content/help/system-requirements.adoc
@@ -96,7 +96,8 @@ supported distribution and window manager before they will be addressed by KiCad
 |Ubuntu 18.10|1-Apr-2019
 |Debian 9 (Stretch)|approx 2020
 |Debian 10 (Buster)|approx 2022
-|Fedora 29|approx May 2019
+|Fedora 29|approx November 2019
+|Fedora 30|approx May 2020
 |===
 
 [%hardbreaks]


### PR DESCRIPTION
Update the Fedora EOL dates now that Fedora 30 has been released.  In general a Fedora release has about a one year life-span.