### PR TITLE
Update Mac OS version to 10.12

### DIFF
--- a/content/download/osx.adoc
+++ b/content/download/osx.adoc
@@ -33,7 +33,7 @@ Current Version: *5.1.4*
 
 
 ++++
-<h3>macOS 10.11-10.13</h3>
+<h3>macOS 10.12-10.13</h3>
 <h4>Download mirrors</h4>
 <div class="list-group download-list-group">
 	<a class="list-group-item" href="https://kicad-downloads.s3.cern.ch/osx/stable/kicad-unified-5.1.4-0.dmg">


### PR DESCRIPTION
The header in the download section still had 10.11 in it, and it caused some user confusion. This updates that reference to be 10.12 now.