### PR TITLE
Update release notice link to point to 5.1.4

### DIFF
--- a/layouts/section/download.html
+++ b/layouts/section/download.html
@@ -22,7 +22,7 @@
 				<h1>{{ .Title }}</h1>
 			</div>
 			<p>
-				KiCad 5.1.4 was released in August 2019. <a href="http://kicad-pcb.org/post/release-5.1.2/">See the announcement on the blog</a>. Details on the availability for your platform can be seen for each of the platforms below.
+				KiCad 5.1.4 was released in August 2019. <a href="http://kicad-pcb.org/post/release-5.1.4/">See the announcement on the blog</a>. Details on the availability for your platform can be seen for each of the platforms below.
 			</p>
 			<h3>Select your operating system or distribution</h3>
 			<div class="row">


### PR DESCRIPTION
Fix an incorrect link pointing to the old 5.1.2 release notice on the downloads page.