### PR TITLE
Update High DPI advice on the known issues page

### DIFF
--- a/content/help/known-system-related-issues.adoc
+++ b/content/help/known-system-related-issues.adoc
@@ -19,10 +19,14 @@ means that this page does not describe KiCad functional bugs.
 
 === High DPI Screens
 
-There are some issues with detecting the proper scaling of the canvas
-on High DPI screens. This mainly seems to affect Linux installs, and
-results in the canvas only using 1/4 of the screen and a constant
-offset between the cursor and crosshairs https://bugs.launchpad.net/kicad/+bug/1841423[(see Bug #1841423]
+KiCad is configured to automatically detect the proper scaling factor for
+displaying the editor canvas on the screen by default. If the canvas only uses
+1/4 of the screen and there is a constant offset between the cursor and
+crosshairs, check to ensure that automatic canvas scaling is enabled on the
+common settings page of the Preferences dialog.
+
+There are some known issues that can cause the canvas to not automatically scale
+properly, primarily on Linux installations (https://bugs.launchpad.net/kicad/+bug/1841423[see Bug #1841423]
 and https://bugs.launchpad.net/kicad/+bug/1797308[Bug #1797308)].
 To fix this, disable the automatic canvas scaling in the preferences
 window and enter a custom scale factor. In most cases a scaling factor
@@ -33,7 +37,7 @@ can be scaled in the preferences window as well.
 
 The grid dots may be difficult to see due to their smaller size on
 these displays. On the modern canvas, their size can be increased
-in the preferences window https://bugs.launchpad.net/kicad/+bug/1660560[(see Bug #1660560)]
+in the preferences window https://bugs.launchpad.net/kicad/+bug/1660560[(see Bug #1660560)].
 
 
 === Legacy Canvas and wxGTK


### PR DESCRIPTION
Rephrase the advice for High DPI screens to specify that automatic scaling is an option that should be enabled by default, and describe where to modify it if it is not enabled.