### PR TITLE
Add Fedora 31 to the web pages

### DIFF
--- a/content/download/fedora.adoc
+++ b/content/download/fedora.adoc
@@ -10,6 +10,8 @@ weight = 20
 
 {{< repology fedora_rawhide >}}
 
+{{< repology fedora_31 >}}
+
 {{< repology fedora_30 >}}
 
 {{< repology fedora_29 >}}

--- a/content/help/system-requirements.adoc
+++ b/content/help/system-requirements.adoc
@@ -98,6 +98,7 @@ supported distribution and window manager before they will be addressed by KiCad
 |Debian 10 (Buster)|approx 2022
 |Fedora 29|approx November 2019
 |Fedora 30|approx May 2020
+|Fedora 31|approx November 2020
 |===
 
 [%hardbreaks]


### PR DESCRIPTION
Fedora 31 is now released, so update the web pages to include it.