### PR TITLE
Remove dead mailing list

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -63,12 +63,6 @@ disablePathToLower = true
     weight = 10
 
 [[menu.main]]
-    parent = "Community"
-    name   = "User Mailing List"
-    url    = "https://groups.yahoo.com/neo/groups/kicad-users/info"
-    weight = 15
-
-[[menu.main]]
     name   = "Help"
     weight = 100
 


### PR DESCRIPTION
Yahoo discontinued their mailing list service in Oct.