### PR TITLE
Adding an unsupported note to relevant distros

### DIFF
--- a/content/download/_supported-note.adoc
+++ b/content/download/_supported-note.adoc
@@ -1,0 +1,5 @@
+== Important Note for {dist} Users
+{dist} is not officially supported by the KiCad project.  This link is provided as a reference to {dist} users 
+but the KiCad project cannot guarantee that users will not encounter distribution-specific issues.  Issues encountered
+while using {dist} will need to be recreated in a http://kicad-pcb.org/help/system-requirements/#_gnulinux[supported distribution]
+before the KiCad developers can address it.

--- a/content/download/flatpak.adoc
+++ b/content/download/flatpak.adoc
@@ -5,6 +5,9 @@ weight = 30
 +++
 :icons: fonts
 :iconsdir: /img/icons/
+:dist: Flatpak
+
+include::./content/download/_supported-note.adoc[]
 
 == Stable Release
 

--- a/content/download/freebsd.adoc
+++ b/content/download/freebsd.adoc
@@ -5,6 +5,9 @@ weight = 96
 +++
 :icons: fonts
 :iconsdir: /img/icons/
+:dist: FreeBSD
+
+include::./content/download/_supported-note.adoc[]
 
 == Stable Release
 

--- a/content/download/gentoo.adoc
+++ b/content/download/gentoo.adoc
@@ -5,6 +5,9 @@ weight = 95
 +++
 :icons: fonts
 :iconsdir: /img/icons/
+:dist: Gentoo
+
+include::./content/download/_supported-note.adoc[]
 
 == Stable Release
 

--- a/content/download/linux-mint.adoc
+++ b/content/download/linux-mint.adoc
@@ -1,10 +1,13 @@
 +++
 title = "Linux Mint"
 iconhtml = "<div class='fl-linuxmint'></div>"
-weight = 11
+weight = 21
 +++
 :icons: fonts
 :iconsdir: /img/icons/
+:dist: Linux Mint
+
+include::./content/download/_supported-note.adoc[]
 
 === Linux Mint Debian Incompatibility
 Linux Mint Debian does not work with the PPA listed below.  Only Linux Mint Ubuntu and its derivatives have been 

--- a/content/download/open-suse.adoc
+++ b/content/download/open-suse.adoc
@@ -5,6 +5,9 @@ weight = 20
 +++
 :icons: fonts
 :iconsdir: /img/icons/
+:dist: openSUSE
+
+include::./content/download/_supported-note.adoc[]
 
 == Stable release
 {{< repology opensuse_tumbleweed >}}

--- a/content/download/sabayon.adoc
+++ b/content/download/sabayon.adoc
@@ -5,6 +5,9 @@ weight = 95
 +++
 :icons: fonts
 :iconsdir: /img/icons/
+:dist: Sabayon
+
+include::./content/download/_supported-note.adoc[]
 
 == Stable Release
 KiCad 5.1.4 is available in in the


### PR DESCRIPTION
While we provide distribution links to various linux distros, it is
important that users see the limitations of our support policy when
downloading.

This also downgrades the placement of Linux Mint below the supported distributions