### PR TITLE
Clarify preferred donation path

### DIFF
--- a/layouts/partials/donate.html
+++ b/layouts/partials/donate.html
@@ -1,13 +1,15 @@
-<h3>CERN</h3>
-<p>
-	CERN has been a long term supporter of KiCad by providing engineers that work on KiCad 
-	to further both their own needs and that of the greater community.
-	Donating allocates money directly for engineers to work on KiCad.
-	<a class="btn btn-primary btn-block plain-link" href="https://cernandsocietyfoundation.cern/projects/kicad">Donate</a>
-</p>
-<hr />
 <h3>The Linux Foundation&reg;</h3>
 <p>
-	Donating to KiCad via The Linux Foundation provides funds for project development and the developers behind it.
+	Donating to KiCad via The Linux Foundation is the preferred method of supporting KiCad development.
+	This support provides funds for project development and the developers behind it.
+	The Linux Foundation is a 501(c)(6) non-profit organization in the US.
 	<a class="btn btn-primary btn-block plain-link" href="https://funding.communitybridge.org/projects/kicad">Donate</a>
+</p>
+<hr />
+<h3>CERN</h3>
+<p>
+	CERN is a long time supporter of KiCad.  Donating money via CERN will
+	fund CERN's engineering effort to work on KiCad.  Your country's tax laws 
+	may provide you with a benefit for this donation.
+	<a class="btn btn-primary btn-block plain-link" href="https://cernandsocietyfoundation.cern/projects/kicad">Donate</a>
 </p>


### PR DESCRIPTION
We have engaged with the Linux Foundation because they offer a much
better means of support for Open Source project development.  We should
make this clear on the website.  There are also significant tax benefits
to US donations for donating via LF.