### PR TITLE
Fedora: Remove instructions regarding the mangelajo/kicad repository.

### DIFF
--- a/content/download/fedora.adoc
+++ b/content/download/fedora.adoc
@@ -56,14 +56,7 @@ separate package and can be installed with:
 [source,bash]
 dnf install kicad-packages3d
 
-The `@kicad/kicad` repository replaces the `mangelajo/kicad` repository that was
-previously used to deliver the development builds. If you've previously used it
-you can safely remove it now:
-
-[source,bash]
-dnf copr remove mangelajo/kicad
-
-If you don't have copr install with:
+If you don't have copr, install it with:
 
 [source,bash]
 dnf install dnf-plugins-core


### PR DESCRIPTION
@nickoe - now that you have removed the reference to mangelajo/kicad from Copr, it probably makes sense to remove it from the KiCad web page too.

This patch does that.