### PR TITLE
KLC F2.2: Add "mm" to footprint name prefix examples

### DIFF
--- a/layouts/shortcodes/fp_prefix.html
+++ b/layouts/shortcodes/fp_prefix.html
@@ -24,7 +24,7 @@
   <td><ul>
     <li>Height of component measured from PCB</li>
     <li>Body size <code>B</code> should be used in preference, where possible</li>
-    <li>e.g. <code>H1.1</code> - component measures 1.1mm above PCB</li>
+    <li>e.g. <code>H1.1mm</code> - component measures 1.1mm above PCB</li>
   </ul></td>
 </tr>
 <tr>
@@ -46,7 +46,7 @@
 <tr>
   <td>EP</td><td>Exposed pad dimensions</td>
   <td><ul>
-    <li>Packages that include a single exposed pad include the size of this pad. e.g. <code>EP2.4x3.6</code> - for a single 2.4mm x 3.6mm pad.</li>
+    <li>Packages that include a single exposed pad include the size of this pad. e.g. <code>EP2.4x3.6mm</code> - for a single 2.4mm x 3.6mm pad.</li>
   </ul></td>
 </tr>
 <tr>


### PR DESCRIPTION
This makes the examples consistent with other examples and current
practice.