### PR TITLE
Improve S4.2 examples

### DIFF
--- a/content/klc/S4.2.adoc
+++ b/content/klc/S4.2.adoc
@@ -13,8 +13,11 @@ Where possible, pins should be grouped by similar function, rather than by their
 . *Negative power* and *ground* pins should be placed at the _bottom_ of a symbol
   * `GND`, `Vss`, `V-`, etc.
 . *Input/Control/Logic* pins should be placed on the _left_ of a symbol
-  * `UART Tx/Rx`
+  * `Enable`, `Sleep`
+  * `Iset`
 . *Output/Controlled/Driver* pins should be placed on the _right_ of a symbol
-  * `RS232 Tx/Rx`
+  * `Alarm`
+  * `ChargeFinished`
+  * `Q`, `!Q`
 
 {{< klcimg src="S4.2a" title="Pin grouping" >}}

--- a/content/libraries/klc.adoc
+++ b/content/libraries/klc.adoc
@@ -13,7 +13,7 @@ aliases = [ "/klc/" ]
 toc::[]
 
 
-**link:/libraries/klc/history/[Revision: 3.0.26]**
+**link:/libraries/klc/history/[Revision: 3.0.27]**
 
 ---
 

--- a/content/libraries/klc_history.adoc
+++ b/content/libraries/klc_history.adoc
@@ -5,6 +5,9 @@ url = "/libraries/klc/history/"
 +++
 
 ---
+== 3.0.27 - 2020-03-14
+* Rework examples for input- and output-pin grouping/positioning (S4.2)
+
 == 3.0.26 - 2020-01-18
 * Clarify that contributions must be made with the current stable version (G1.8)
 


### PR DESCRIPTION
Rework examples for input- and output-pin grouping/positioning (S4.2)

Related: https://github.com/KiCad/kicad-website/issues/423