### PR TITLE
Modify demo installation samples

### DIFF
--- a/content/download/_js-reynaud-ppa.adoc
+++ b/content/download/_js-reynaud-ppa.adoc
@@ -1,4 +1,4 @@
-:icons: 
+:icons:
 :iconsdir: /img/icons/
 
 == 5.1.5 Stable Release
@@ -28,7 +28,7 @@ sudo add-apt-repository --yes ppa:js-reynaud/kicad-5.1
 sudo apt update
 sudo apt install --install-recommends kicad
 # If you want demo projects
-sudo apt install kicad-demo
+sudo apt install kicad-demos
 
 
 This will perform a full installation of KiCad. If you don't want to install all packages you
@@ -82,7 +82,7 @@ sudo add-apt-repository --yes ppa:js-reynaud/kicad-5
 sudo apt update
 sudo apt install kicad --install-recommends kicad
 # If you want demo projects
-sudo apt install kicad-demo
+sudo apt install kicad-demos
 
 This will perform a full installation of KiCad. If you don't want to install all packages you can use:
 
@@ -148,7 +148,7 @@ sudo apt install kicad-nightly
 # You can also install debug symbols:
 sudo apt install kicad-nightly-dbg
 # Demo
-sudo apt install kicad-nightly-demo
+sudo apt install kicad-nightly-demos
 # and libraries
 sudo apt install kicad-nightly-footprints kicad-nightly-libraries kicad-nightly-packages3d kicad-nightly-symbols kicad-nightly-templates
 
@@ -199,11 +199,11 @@ packages:
 - kicad-templates: Project templates (installed by default)
 - kicad-footprints: All footprints (installed by default)
 - kicad-packages3d: 3D for footprints (installed by default. Could be heavy to download)
-- kicad-demo: demonstration projects (not installed by default)
+- kicad-demos: demonstration projects (not installed by default)
 - kicad-doc-XX: documentation. Replace `XX` by your language code ('fr' for French for instance)
 - kicad-dbg: debug symbols. Useful for bug tracking and developers (not installed by default.
   Could be heavy to download)
 
 To install kicad-demo for example:
 [source,bash]
-sudo apt install kicad-demo
+sudo apt install kicad-demos


### PR DESCRIPTION
When installing either `kicad-nightly-demo` or `kicad-demo`, I get the following messages:


```~$ sudo apt install kicad-demo
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Package kicad-demo is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However, the following packages replace it:
  kicad-demos
```
---
```
~$ sudo apt install kicad-nightly-demo
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Package kicad-nightly-demo is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However, the following packages replace it:
  kicad-nightly-demos
```