### PR TITLE
Debian Stretch: update available version in backports

### DIFF
--- a/content/download/debian.adoc
+++ b/content/download/debian.adoc
@@ -100,7 +100,7 @@ upgrade your system to at least Debian Stretch!
 
 ===== https://packages.debian.org/stretch-backports-sloppy/kicad[*Old-Stable* (Backports)]
 
-Version: 5.1.4
+Version: 5.1.6
 
 ====== Installation
 


### PR DESCRIPTION
Small update after the backported package for KiCad got accepted into stretch-backports-sloppy.