### PR TITLE
Fedora 30 is now EOL

### DIFF
--- a/content/download/fedora.adoc
+++ b/content/download/fedora.adoc
@@ -15,8 +15,6 @@ weight = 20
 
 {{< repology fedora_31 >}}
 
-{{< repology fedora_30 >}}
-
 In general, latest Fedora releases ship the stable versions of KiCad as they are
 released.
 


### PR DESCRIPTION
Fedora 30 has gone EOL, so it should be removed from the KiCad web site.