### PR TITLE
add instructions for Linux MATE desktop

### DIFF
--- a/content/help/known-system-related-issues.adoc
+++ b/content/help/known-system-related-issues.adoc
@@ -132,7 +132,7 @@ Some versions of MATE (on Ubuntu or Linux Mint) together with GTK3 and wxWidgets
 and keyboard keys that do not work or can freeze the GUI input. They are potentially caused
 by the ibus. To solve it, install the packages ibus-gtk and ibus-gtk3, and restart the computer (or log out).
 Alternatively, you can quit the ibus calling in a terminal 'ibus exit' before starting KiCad.  
-link:https://gitlab.com/kicad/code/kicad/-/issues/4547[See the bug tracker for more details].
+More details can be found in link:https://gitlab.com/kicad/code/kicad/-/issues/4547[GitLab Bug# 4547].
 
 == Windows
 === wxWidgets 3.0.2

--- a/content/help/known-system-related-issues.adoc
+++ b/content/help/known-system-related-issues.adoc
@@ -126,6 +126,14 @@ KiCad requests the XWayland compatibility layer when starting, however this is
 an emulation mode and issues arising while using this mode need to be recreated
 under X11 before they will be addressed.
 
+=== MATE
+
+Some versions of MATE (on Ubuntu or Linux Mint) together with GTK3 and wxWidgets can lead to rendering problems
+and keyboard keys that do not work or can freeze the GUI input. They are potentially caused
+by the ibus. To solve it, install the packages ibus-gtk and ibus-gtk3, and restart the computer (or log out).
+Alternatively, you can quit the ibus calling in a terminal 'ibus exit' before starting KiCad.  
+link:https://gitlab.com/kicad/code/kicad/-/issues/4547[See the bug tracker for more details].
+
 == Windows
 === wxWidgets 3.0.2
 

--- a/content/help/system-requirements.adoc
+++ b/content/help/system-requirements.adoc
@@ -153,9 +153,6 @@ the following window managers:
 * i3 (Arch Linux)
 * Unity (Ubuntu prior to 18.04)
 
-MATE is not officially supported. Check for related issues  
-link:/help/known-system-related-issues/#_mate[here]. 
-
 ==== Graphical Windowing Backend
 Regardless of the window manager, KiCad officially only supports the X11 backend.  Users who
 choose to use Wayland will have to run KiCad in the compatibility layer

--- a/content/help/system-requirements.adoc
+++ b/content/help/system-requirements.adoc
@@ -153,7 +153,7 @@ the following window managers:
 * i3 (Arch Linux)
 * Unity (Ubuntu prior to 18.04)
 
-MATE is not officially supported, but works well in most cases. Check for some issues  
+MATE is not officially supported. Check for related issues  
 link:/help/known-system-related-issues/#_mate[here]. 
 
 ==== Graphical Windowing Backend

--- a/content/help/system-requirements.adoc
+++ b/content/help/system-requirements.adoc
@@ -153,8 +153,8 @@ the following window managers:
 * i3 (Arch Linux)
 * Unity (Ubuntu prior to 18.04)
 
-In case you use MATE (not officially supported) and find rendering problems and keys that do not
-work or that freeze the input, you should check : link:/help/known-system-related-issues/#_mate[these solutions]. 
+MATE is not officially supported, but works well in most cases. Check for some issues  
+link:/help/known-system-related-issues/#_mate[here]. 
 
 ==== Graphical Windowing Backend
 Regardless of the window manager, KiCad officially only supports the X11 backend.  Users who

--- a/content/help/system-requirements.adoc
+++ b/content/help/system-requirements.adoc
@@ -153,6 +153,9 @@ the following window managers:
 * i3 (Arch Linux)
 * Unity (Ubuntu prior to 18.04)
 
+In case you use MATE (not officially supported) and find rendering problems and keys that do not
+work or that freeze the input, you should check : link:/help/known-system-related-issues/#_mate[these solutions]. 
+
 ==== Graphical Windowing Backend
 Regardless of the window manager, KiCad officially only supports the X11 backend.  Users who
 choose to use Wayland will have to run KiCad in the compatibility layer


### PR DESCRIPTION
depending on the version, there are some issues with GTK and wxWidgets, that need extra package installations.